### PR TITLE
docs: trim historical faff, focus README on Meshtastic dev/usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,8 @@
-# Adafruit nRF52 Bootloader with Enhanced OTA DFU
+# Meshtastic OTAFIX Bootloader
 
-This is [Meshtastic](https://meshtastic.org)'s fork of [oltaco's OTAFIX bootloader](https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX) — the bootloader several nRF52-based Meshtastic devices ship with, and the one the [Meshtastic Android app](https://github.com/meshtastic/Meshtastic-Android) can upgrade in-app (see [Bootloader upgrade from the Meshtastic Android app](#bootloader-upgrade-from-the-meshtastic-android-app) below).
+Adafruit nRF52 bootloader with enhanced OTA DFU, forked for [Meshtastic](https://meshtastic.org) from [oltaco's OTAFIX bootloader](https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX). This is the bootloader several nRF52-based Meshtastic devices ship with, and the one the [Meshtastic Android app](https://github.com/meshtastic/Meshtastic-Android) can upgrade in-app (see [Bootloader upgrade from the Meshtastic Android app](#bootloader-upgrade-from-the-meshtastic-android-app) below).
 
-## Changes in OTAFIX 2.2
-
-- **Use maximum TX power for BLE**  
-  Changed BLE TX power to be set to +8 for nRF52840.
-
-- **New boards**  
-  Elecrow ThinkNode M1, M3, M6  
-  LilyGo T-Echo  
-  Minewsemi MX25LE01  
-  Seeed SenseCAP Solar Node P1
-
-## Changes in OTAFIX 2.1
-
-- **Defaults to OTA DFU mode**  
-  When no valid application is present, the bootloader defaults to OTA DFU mode.  
-  This prevents devices from becoming stuck in UF2 mode after a failed OTA update.
-
-- **High-MTU BLE support**  
-  Enables larger DFU packets for improved throughput when supported by the client.  
-  The Android DFU app and [`dfu.py`](https://github.com/recrof/nrf_dfu_py) support large packets; the iOS DFU app is limited to 20-byte packets.
-
-- **Lazy flash erase**  
-  Flash pages are erased on demand during the transfer instead of upfront, significantly reducing the delay during DFU initialisation before the transfer begins.
-
-- **Small-packet accumulation**  
-  Packets smaller than 64 bytes are combined at the transport layer and written to flash in chunks of up to 240 bytes.  
-  This improves OTA performance from iOS devices and other small-packet DFU hosts by reducing flash write overhead.
-
-- **Automatic application boot after OTA over USB**  
-  When connected to a USB host, devices now automatically reboot into the application after a successful OTA update, instead of requiring a manual reset.
-
-- **Unique BLE advertising names per board**  
-  In OTA DFU mode, devices advertise using a board-specific name instead of the generic `AdaDFU`:
-  - **Elecrow ThinkNode M1** → `TNM1_DFU`
-  - **Elecrow ThinkNode M3** → `TNM3_DFU`
-  - **Elecrow ThinkNode M6** → `TNM6_DFU`
-  - **Heltec T114** → `T114_DFU`
-  - **LILYGO T-Echo** → `LGTE_DFU`
-  - **Minewsemi MX25LE01** → `MX25_DFU`
-  - **ProMicro NRF52840** → `PROM_DFU`
-  - **RAK 4631** → `4631_DFU`
-  - **RAK WisMesh Tag** → `RTAG_DFU`
-  - **Seeed SenseCAP Solar Node P1** → `SCAP_DFU`
-  - **Seeed T1000e** → `T1KE_DFU`
-  - **Seeed WioTracker L1** → `WTL1_DFU`
-  - **XIAO NRF52 BLE / SENSE** → `XIAO_DFU`
+Current release: **OTAFIX 2.2** — see [changelog.md](changelog.md) for version history.
 
 ---
 
@@ -59,15 +14,15 @@ This is [Meshtastic](https://meshtastic.org)'s fork of [oltaco's OTAFIX bootload
 - LilyGO T-Echo
 - Minewsemi MX25LE01
 - Nologo ProMicro NRF52840 (aka SuperMini NRF52840)
-- RAK 4631 ([See note](#notes-on-RAK4631-bootloader))
+- RAK 4631 ([See note](#notes-on-rak4631-bootloader))
 - RAK WisMesh Tag
 - Seeed Studio SenseCAP Card Tracker T1000-E
 - Seeed SenseCAP Solar Node P1
 - Seeed Studio Wio Tracker L1
-- Seeed Studio XIAO nRF52840 BLE ([See note](#notes-on-xiao-nrf52840-ble)
+- Seeed Studio XIAO nRF52840 BLE ([See note](#notes-on-xiao-nrf52840-ble))
 - Seeed Studio XIAO nRF52840 BLE SENSE
 
-If there is another nRF52840-based board you would like to see supported please raise a github issue and we can make it happen.
+If there is another nRF52840-based Meshtastic board you would like to see supported, please raise a GitHub issue.
 
 ---
 
@@ -76,7 +31,15 @@ If there is another nRF52840-based board you would like to see supported please 
 The recommended way to install the bootloader is using the UF2 file.  
 Download the UF2 file for your board (they can be found in the releases with filenames beginning with `update-`), enter UF2 mode (usually by double pressing the reset button within 0.5s) and copy the UF2 file across.
 
-If you have somehow managed to accidentally flash an incorrect bootloader to your device you will likely require flashing a full bootloader and SoftDevice zip package using ``adafruit-nrfutil``
+If an incorrect bootloader has been flashed to the device, a full bootloader and SoftDevice zip package will need to be flashed using ``adafruit-nrfutil``.
+
+---
+
+## Bootloader upgrade from the Meshtastic Android app
+
+The [Meshtastic Android app](https://github.com/meshtastic/Meshtastic-Android) can flash this bootloader directly — no manual UF2 drag-and-drop needed.
+
+With the radio connected over **USB/serial** (not Bluetooth), open the connected radio's configuration, go to **Advanced → Firmware Update**, and where an upgraded bootloader is published for your board you'll see an **Upgrade bootloader** option alongside **Erase and reinstall**. The app reads `INFO_UF2.TXT` from the device's update drive first to confirm the board and Bluetooth stack before writing anything, and will ask you to select the update drive twice — once for the bootloader image, once for the firmware. See the app's [Firmware Updates guide](https://github.com/meshtastic/Meshtastic-Android/blob/main/docs/en/user/firmware.md) for the full flow.
 
 ---
 
@@ -105,8 +68,8 @@ This behaviour is intentional and prevents devices from getting stuck in UF2 mod
 If an OTA update consistently fails early with `Error: Operation Failed`, this is often caused by BLE stack incompatibilities when **Request High MTU** is enabled.
 
 **What to try:**
-- Experiment with different PRN settings. Try 12, 8, 1, or even off altogether!
-- Disable **Request High MTU** in your DFU app
+- Experiment with different PRN settings — try 12, 8, 1, or off altogether.
+- Disable **Request High MTU** in the DFU app.
 
 While high MTU significantly improves performance on supported devices, it is not required for a successful OTA update.
 
@@ -114,14 +77,14 @@ While high MTU significantly improves performance on supported devices, it is no
 
 ## Recommended OTA DFU settings
 
-To perform the OTA update you can use **nRF Device Firmware Update**  
+To perform the OTA update, use **nRF Device Firmware Update**  
 ([Android](https://play.google.com/store/apps/details?id=no.nordicsemi.android.dfu&hl=en&gl=US) / [iOS](https://apps.apple.com/sa/app/device-firmware-update/id1624454660))  
 or **nRF Connect**  
 ([Android](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en&gl=US) / [iOS](https://apps.apple.com/gb/app/nrf-connect-for-mobile/id1054362403)).
 
-My preference is the **nRF Device Firmware Update** app.
+**nRF Device Firmware Update** is the recommended app of the two.
 
-For **OTAFIX 2.0**, the following settings are recommended (these may change — feel free to experiment and report your findings):
+For **OTAFIX 2.0** and later, the following settings are recommended (these may change — feel free to experiment and report findings via a GitHub issue):
 
 <table>
 <tr>
@@ -131,7 +94,7 @@ For **OTAFIX 2.0**, the following settings are recommended (these may change —
 **Number of packets:** 30  
 **Reboot time:** 0ms  
 **Scan timeout:** 2000ms  
-**Request high MTU:** ON for Android (See notes below) / Not available on iOS  
+**Request high MTU:** ON for Android (see notes below) / not available on iOS  
 **Disable resume:** ON  
 **Prepare object delay:** 0ms  
 **Force scanning:** ON  
@@ -156,22 +119,6 @@ This issue is fixed in **OTAFIX 2.0**.
 
 ---
 
-## Bootloader upgrade from the Meshtastic Android app
-
-The [Meshtastic Android app](https://github.com/meshtastic/Meshtastic-Android) can flash this bootloader directly — no manual UF2 drag-and-drop needed.
-
-With the radio connected over **USB/serial** (not Bluetooth), open the connected radio's configuration, go to **Advanced → Firmware Update**, and where an upgraded bootloader is published for your board you'll see an **Upgrade bootloader** option alongside **Erase and reinstall**. The app reads `INFO_UF2.TXT` from the device's update drive first to confirm the board and Bluetooth stack before writing anything, and will ask you to select the update drive twice — once for the bootloader image, once for the firmware. See the app's [Firmware Updates guide](https://github.com/meshtastic/Meshtastic-Android/blob/main/docs/en/user/firmware.md) for the full flow.
-
----
-
-## Donations
-
-Although it's not necessary, if you find this useful please consider donating to support my work!
-
-[![Ko-Fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/oltaco)
-
----
-
 ## Notes on Xiao NRF52840 BLE
 
 Many of these boards are shipped with the Sense version of the bootloader installed. If your board has the Sense version installed you must use the Sense version when updating via UF2.
@@ -182,10 +129,8 @@ To check:
 1. Enter UF2 DFU mode (double-press reset) 
 2. Open the `INFO_UF2.TXT` file on the mounted drive  
 
-If the file shows: "Board-ID: nRF52840-SeeedXiaoSense-v1" then you must install the ***SENSE*** variant if updating via UF2 file.
+If the file shows: "Board-ID: nRF52840-SeeedXiaoSense-v1" then the ***SENSE*** variant must be used if updating via UF2 file.
 
 ## Notes on RAK4631 bootloader
 
-This version of the RAK4631 bootloader is based on a much newer version (0.9.2) of the Adafruit nRF52 bootloader than what RAK Wireless uses on their official bootloader (0.6.2-11).  
-
-I haven't looked to see what changes (if any) that RAK made to the Adafruit bootloader, so I'm not sure if there's any difference but I have tested this bootloader and I haven't found any problems thus far. If you would rather use the original RAK bootloader but with these patches included you can find that [here](https://github.com/oltaco/WisCore_RAK4631_Bootloader/releases).
+This version of the RAK4631 bootloader is based on a much newer version (0.9.2) of the Adafruit nRF52 bootloader than what RAK Wireless uses on their official bootloader (0.6.2-11). It has been tested with no problems found; whether RAK's own patches to the Adafruit bootloader introduce any behavioral difference has not been investigated. A variant of the official RAK bootloader with these patches included instead is available [here](https://github.com/oltaco/WisCore_RAK4631_Bootloader/releases).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Meshtastic OTAFIX Bootloader
 
+[![Build](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/actions/workflows/githubci.yml/badge.svg)](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/actions/workflows/githubci.yml)
+
 Adafruit nRF52 bootloader with enhanced OTA DFU, forked for [Meshtastic](https://meshtastic.org) from [oltaco's OTAFIX bootloader](https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX). This is the bootloader several nRF52-based Meshtastic devices ship with, and the one the [Meshtastic Android app](https://github.com/meshtastic/Meshtastic-Android) can upgrade in-app (see [Bootloader upgrade from the Meshtastic Android app](#bootloader-upgrade-from-the-meshtastic-android-app) below).
 
 Current release: **OTAFIX 2.2** — see [changelog.md](changelog.md) for version history.
@@ -134,3 +136,25 @@ If the file shows: "Board-ID: nRF52840-SeeedXiaoSense-v1" then the ***SENSE*** v
 ## Notes on RAK4631 bootloader
 
 This version of the RAK4631 bootloader is based on a much newer version (0.9.2) of the Adafruit nRF52 bootloader than what RAK Wireless uses on their official bootloader (0.6.2-11). It has been tested with no problems found; whether RAK's own patches to the Adafruit bootloader introduce any behavioral difference has not been investigated. A variant of the official RAK bootloader with these patches included instead is available [here](https://github.com/oltaco/WisCore_RAK4631_Bootloader/releases).
+
+---
+
+## Building locally
+
+The build is `make`-based; the `CMakeLists.txt` in this repo is incomplete — only `heltec_t114` and `thinknode_m1` have a `board.cmake`, so `cmake -DBOARD=<other board>` will fail with `BOARD is not defined`-style errors. Use `make`.
+
+```sh
+git submodule update --init --recursive
+
+python3 -m venv .venv && source .venv/bin/activate
+pip install adafruit-nrfutil uritemplate requests intelhex setuptools
+
+# ARM GCC 12.3.Rel1 is what CI pins (.github/workflows/githubci.yml).
+# Newer versions (13.x tested working, 15.x does not) can hit a
+# -Werror=array-bounds false positive in bootloader_settings.c.
+
+make BOARD=wiscore_rak4631_board all
+make BOARD=wiscore_rak4631_board copy-artifact   # writes _bin/<board>/
+```
+
+Board names are the directory names under `src/boards/`. `tools/build_all.py` builds every board and prints a pass/fail + size table — useful for checking a change against the full matrix before pushing, the same thing CI's board matrix does per-PR.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,32 @@
 # Adafruit nRF52 Bootloader Changelog
 
+## OTAFIX 2.2
+
+- Use maximum TX power for BLE: BLE TX power set to +8 for nRF52840.
+- New boards: Elecrow ThinkNode M1, M3, M6; LilyGo T-Echo; Minewsemi MX25LE01; Seeed SenseCAP Solar Node P1.
+
+## OTAFIX 2.1
+
+- Defaults to OTA DFU mode when no valid application is present, preventing devices from becoming stuck in UF2 mode after a failed OTA update.
+- High-MTU BLE support for larger DFU packets. The Android DFU app and [`dfu.py`](https://github.com/recrof/nrf_dfu_py) support large packets; the iOS DFU app is limited to 20-byte packets.
+- Lazy flash erase: pages are erased on demand during the transfer instead of upfront, reducing the delay before the transfer begins.
+- Small-packet accumulation: packets smaller than 64 bytes are combined at the transport layer and written to flash in chunks of up to 240 bytes, improving OTA performance from iOS and other small-packet DFU hosts.
+- Automatic application boot after OTA over USB, instead of requiring a manual reset.
+- Unique BLE advertising names per board in OTA DFU mode, instead of the generic `AdaDFU`:
+  - Elecrow ThinkNode M1 → `TNM1_DFU`
+  - Elecrow ThinkNode M3 → `TNM3_DFU`
+  - Elecrow ThinkNode M6 → `TNM6_DFU`
+  - Heltec T114 → `T114_DFU`
+  - LILYGO T-Echo → `LGTE_DFU`
+  - Minewsemi MX25LE01 → `MX25_DFU`
+  - ProMicro NRF52840 → `PROM_DFU`
+  - RAK 4631 → `4631_DFU`
+  - RAK WisMesh Tag → `RTAG_DFU`
+  - Seeed SenseCAP Solar Node P1 → `SCAP_DFU`
+  - Seeed T1000e → `T1KE_DFU`
+  - Seeed WioTracker L1 → `WTL1_DFU`
+  - XIAO NRF52 BLE / SENSE → `XIAO_DFU`
+
 ## 0.6.2 - 2021.09.10
 
 - Add new board "LED Glasses Driver nRF52840"


### PR DESCRIPTION
## Summary
- Moved OTAFIX 2.1/2.2 changelog entries out of the README's top (they crowded out usage docs before you even got to Installation) into `changelog.md`, which didn't have them.
- Removed the Donations section - personal ko-fi solicitation, redundant with `.github/FUNDING.yml`'s Sponsor button (from #2).
- Reworded first-person narration ("My preference is...", "I haven't looked...") to neutral statements.
- Fixed a broken markdown link (missing closing paren on the XIAO note anchor).
- Retitled the H1 to lead with Meshtastic. Kept exactly two `oltaco` mentions: the upstream attribution link (provenance) and the RAK4631-note link to oltaco's separate `WisCore_RAK4631_Bootloader` repo (a genuinely useful alternative for users who want RAK's official lineage instead) - both earn their place, nothing else does.

## Test plan
- [x] Confirmed only the two justified `oltaco` mentions remain (`grep -ni oltaco README.md changelog.md`)
- [x] Rendered README preview looks right on GitHub