### PR TITLE
ci: build hygiene - ignore artifacts, cancel superseded runs, cap retention

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -61,6 +61,7 @@ jobs:
       with:
         name: ${{ matrix.board }}
         path: _bin/${{ matrix.board }}
+        retention-days: ${{ github.event_name == 'release' && 90 || 1 }}
 
     - name: Upload Release Asset
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -8,6 +8,10 @@ on:
     types:
       - created
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   set-matrix:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ dkms.conf
 
 segger/Output
 _build/
+_bin/
 bin/
 *.emSession
 *.jlink


### PR DESCRIPTION
## Summary
Follow-on from #2's `pull_request` CI trigger - three small hygiene fixes now that every PR builds the full ~14-board matrix:

- `.gitignore`: `_bin/` (the Makefile's `copy-artifact` output dir) wasn't ignored. Verified by actually running `make BOARD=wiscore_rak4631_board copy-artifact` locally - it showed up as untracked, one `git add -A` away from landing in a commit.
- `concurrency` group added so pushing again to a PR cancels the in-flight matrix build instead of both running to completion.
- `retention-days` on the per-board artifact upload: 90 days (unchanged) for release builds, 1 day for PR validation builds - those only exist to prove the build passed, not to be downloaded.

## Test plan
- [x] `_bin/` confirmed as the actual build output path from a real local build
- [x] YAML is valid (indentation/structure checked by hand)