### PR TITLE
build: add Renovate config for submodules and GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":dependencyDashboard",
+    ":semanticCommitTypeAll(chore)",
+    ":ignoreModulesAndTests",
+    ":noUnscheduledUpdates",
+    "schedule:daily",
+    "group:recommended",
+    "replacements:all",
+    "workarounds:all"
+  ],
+  "baseBranchPatterns": ["master"],
+  "git-submodules": {
+    "enabled": true
+  },
+  "labels": ["dependencies"]
+}


### PR DESCRIPTION
## Summary
The vendored submodules are seriously out of date - checked each pinned commit against upstream HEAD:

| Submodule | Pinned | Upstream HEAD | Age |
|---|---|---|---|
| `lib/nrfx` | 2019-11-06 | 2026-07-23 | ~7 years |
| `lib/tinyusb` | 2021-11-30 | 2026-08-18 | ~5 years |
| `lib/uf2` | 2020-01-09 | 2026-02-08 | ~6 years |

None of that drift is automated - nothing bumps a submodule or a GitHub Actions version today until a human happens to notice. The pinned Actions are also behind: `actions/checkout@v4` and `actions/upload-artifact@v4` are 3 majors behind current, `softprops/action-gh-release@v1` is 2 majors behind.

This PR does **not** bump anything - these are boot-critical vendored dependencies (some of the "OTA update fails" flakiness in the Troubleshooting section could plausibly trace to a 5-year-old tinyusb, but that's a hypothesis, not something to act on blind). It just surfaces the drift as individual, reviewable PRs on a daily schedule instead of leaving it invisible, so each bump can get real hardware testing before merge.

Modeled on `meshtastic/firmware`'s `renovate.json` - the only other repo in the org with a comparable `git-submodules` setup.

## Test plan
- [x] `jq . renovate.json` - valid JSON
- [ ] Confirm the org's Renovate app installation actually picks up this new repo (may need adding to an allowlist if the app isn't set to all-repos)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated project maintenance updates are now scheduled regularly.
  * Related updates will be grouped and tracked through a centralized dashboard.
  * No direct changes to the user experience or product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->