### PR TITLE
ci: scope GITHUB_TOKEN to least privilege

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -8,6 +8,15 @@ on:
     types:
       - created
 
+# The repo's default is write (checked via `gh api .../actions/permissions/workflow`),
+# so every job here would otherwise get a write-capable GITHUB_TOKEN even
+# though only the release-asset upload needs one — and this workflow now
+# runs on every PR, including from forks. contents:write is scoped to the
+# one job that needs it (the release step, gated separately by
+# `if: github.event_name == 'release'`); everything else gets read-only.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -32,6 +41,10 @@ jobs:
   build:
     needs: set-matrix
     runs-on: ubuntu-latest
+    # Only this job's release step needs write access (softprops/action-gh-release
+    # creating/updating release assets); PR runs never reach that step.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
Checked the repo's Actions defaults: `default_workflow_permissions: write`. With no `permissions:` block in `githubci.yml`, every job got a write-capable `GITHUB_TOKEN` — including the `build` job, which now runs on every PR (forks included, since #2 added the `pull_request` trigger).

Only the release-asset upload (`softprops/action-gh-release`, gated to `github.event_name == 'release'`) actually needs write access. Added a top-level `permissions: contents: read`, overridden to `contents: write` on just the `build` job.

Not done here, flagging for later: the release step lives in the same job as the PR-only build/artifact steps, so a genuinely tighter setup would split `publish-release` into its own job (`needs: build`, `if: github.event_name == 'release'`, downloads the artifact) so the PR path never even has a write-capable token in scope. Left as a bigger refactor for another pass.

## Test plan
- [x] `yq eval '.' .github/workflows/githubci.yml` — valid YAML
- [x] `actions/upload-artifact` is unaffected by `permissions:` (uses its own Actions Results API token, not `GITHUB_TOKEN`) — verified this is standard behavior, not assumed