### PR TITLE
ci: pin GitHub Actions to commit SHA, not mutable tags

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set matrix
         id: set-matrix
@@ -51,13 +51,13 @@ jobs:
         board: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
         submodules: true
 
     - name: Install ARM GCC
-      uses: carlosperate/arm-none-eabi-gcc-action@v1
+      uses: carlosperate/arm-none-eabi-gcc-action@98c40e51546516419841748d3210c290df0d2c6c # v1.13.0
       with:
         release: '12.3.Rel1'
 
@@ -70,14 +70,14 @@ jobs:
         make BOARD=${{ matrix.board }} all
         make BOARD=${{ matrix.board }} copy-artifact
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ matrix.board }}
         path: _bin/${{ matrix.board }}
         retention-days: ${{ github.event_name == 'release' && 90 || 1 }}
 
     - name: Upload Release Asset
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       if: ${{ github.event_name == 'release' }}
       with:
         files: |

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
     "schedule:daily",
     "group:recommended",
     "replacements:all",
-    "workarounds:all"
+    "workarounds:all",
+    "helpers:pinGitHubActionDigests"
   ],
   "baseBranchPatterns": ["master"],
   "git-submodules": {


### PR DESCRIPTION
## Summary
Org-level `sha_pinning_required` is off, so all four actions in `githubci.yml` were pinned to floating tags - a supply-chain risk (a compromised or hijacked tag moves without the workflow file changing). Pinned each to the exact commit its current tag resolves to; no functional or version change:

| Action | Tag | Resolved to |
|---|---|---|
| `actions/checkout` | `v4` | `v4.4.0` |
| `actions/upload-artifact` | `v4` | `v4.6.2` |
| `carlosperate/arm-none-eabi-gcc-action` | `v1` | `v1.13.0` |
| `softprops/action-gh-release` | `v1` | `v1` (no semver tag exists on this repo's v1 line) |

Added `helpers:pinGitHubActionDigests` to `renovate.json` (#7) so future version bumps keep the pin-with-comment format instead of reverting to a floating tag.

## Test plan
- [x] `yq eval '.' .github/workflows/githubci.yml` - valid YAML
- [x] `jq . renovate.json` - valid JSON
- [x] Each SHA verified as the actual commit its tag currently resolves to (dereferencing annotated tags where needed, not just trusting the ref object blindly)