### PR TITLE
docs: overhaul for org best practices and dev/usage separation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,46 +10,77 @@ body:
 
   - type: dropdown
     attributes:
-      label: Operating System
+      label: Board
       options:
-              - Linux
-              - MacOS
-              - RaspberryPi OS
-              - Windows 7
-              - Windows 10
-              - Windows 11
-              - Others
+        - Elecrow ThinkNode M1
+        - Elecrow ThinkNode M3
+        - Elecrow ThinkNode M6
+        - Heltec Automation Mesh Node T114
+        - LilyGO T-Echo
+        - Minewsemi MX25LE01
+        - Nologo ProMicro NRF52840 (SuperMini NRF52840)
+        - RAK 4631
+        - RAK WisMesh Tag
+        - Seeed Studio SenseCAP Card Tracker T1000-E
+        - Seeed SenseCAP Solar Node P1
+        - Seeed Studio Wio Tracker L1
+        - Seeed Studio XIAO nRF52840 BLE
+        - Seeed Studio XIAO nRF52840 BLE SENSE
+        - Other / not listed
     validations:
       required: true
+
+  - type: input
+    attributes:
+      label: How did you flash/update the bootloader?
+      placeholder: e.g. Meshtastic Android app (USB), manual UF2 copy, adafruit-nrfutil, nRF Connect OTA
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Operating System (of the computer/phone used to flash, if applicable)
+      options:
+        - Linux
+        - macOS
+        - Windows 10
+        - Windows 11
+        - Android
+        - iOS
+        - Not applicable
+        - Others
+    validations:
+      required: false
 
   - type: textarea
     attributes:
       label: INFO_UF2.TXT
+      description: Enter UF2 mode (double-press reset) and paste the contents of INFO_UF2.TXT from the mounted drive — it identifies the exact bootloader version and board.
       placeholder: Paste your INFO_UF2.TXT contents here
     validations:
       required: true
 
   - type: textarea
     attributes:
-      label: What happened ?
+      label: What happened?
       placeholder: A clear and concise description of what the bug is.
     validations:
       required: true
 
   - type: textarea
     attributes:
-      label: How to reproduce ?
+      label: How to reproduce?
       placeholder: |
         1. Go to '...'
         2. Click on '....'
-        3. See error      
+        3. See error
     validations:
       required: true
 
   - type: textarea
     attributes:
       label: Debug Log
-      placeholder: Debug log attached txt file.
+      placeholder: Debug log attached as a txt file.
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,8 @@
+blank_issues_enabled: false
 contact_links:
-  - name: Adafruit Support Forum
-    url: https://forums.adafruit.com
-    about: If you have other questions or need help, post it here.
+  - name: Meshtastic Discussions
+    url: https://github.com/orgs/meshtastic/discussions
+    about: Questions, troubleshooting, and general discussion — ask here first.
+  - name: Meshtastic Website
+    url: https://meshtastic.org/
+    about: Docs and other ways to reach us.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,16 @@
 ## Checklist
 
-*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*
+*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes.*
+*See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the full dev setup and PR process.*
 
-- [ ] Please provide specific title of the PR describing the change
-- [ ] If you are adding an new boards, please make sure
-  - [ ] Provide link to your allocated VID/PID if applicable
-  - [ ] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)
+- [ ] PR title specifically describes the change
+- [ ] `tools/build_all.py` (or CI's board matrix) passes
+- [ ] If adding a new board, see [Adding a new board](../CONTRIBUTING.md#adding-a-new-board):
+  - [ ] Tested on real hardware, not just compiled
+  - [ ] Link to allocated VID/PID provided, if applicable
+  - [ ] `UF2_BOARD_ID` in `board.h` follows the [UF2 spec](https://github.com/microsoft/uf2#files-exposed-by-bootloaders) format
 
-*This checklist items that are not applicable to your PR can be deleted.*
+*Checklist items that don't apply to your PR can be deleted.*
 
 -----------
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,10 @@ Canonical guidance for AI coding agents and maintainers working in this repo.
 
 1. `README.md` — boards supported, installation, the Meshtastic Android
    in-app upgrade flow, troubleshooting.
-2. `changelog.md` — OTAFIX version history (2.1/2.2 at the top; everything
+2. `CONTRIBUTING.md` — dev setup, PR process, adding a new board.
+3. `changelog.md` — OTAFIX version history (2.1/2.2 at the top; everything
    below predates the OTAFIX fork).
-3. The design invariants and gotchas below — do not violate them.
+4. The design invariants and gotchas below — do not violate them.
 
 ## What this is
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,8 @@ This is C, built with a bare Makefile (the supported path) or `CMakeLists.txt`
 
 ## Build
 
-In the workspace, `nix develop .#otafix` gives you the full toolchain and
-prints these same steps. Outside the workspace, you need `arm-none-eabi-gcc`
-(CI pins **12.3.Rel1** exactly — see the toolchain gotcha below) and Python 3.
+You need `arm-none-eabi-gcc` (CI pins **12.3.Rel1** exactly — see the
+toolchain gotcha below) and Python 3.
 
 ```sh
 git submodule update --init --recursive   # lib/nrfx, lib/tinyusb, lib/uf2 — required, not vendored inline
@@ -110,21 +109,13 @@ itself; a human has to edit it too.
 
 ## Gotchas
 
-- **ARM GCC version matters.** CI pins exactly `12.3.Rel1`. The nixpkgs
-  default (`gcc-arm-embedded`, 15.2.rel1 as of 2026-08) fails with
-  `-Werror=array-bounds` in
+- **ARM GCC version matters.** CI pins exactly `12.3.Rel1`. Much newer
+  toolchains (verified: 15.2.Rel1) fail with `-Werror=array-bounds` in
   `lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c`
   (a false positive from newer GCC's stricter analysis of a fixed
-  MBR-address read) — verified by actually building with it.
-  `gcc-arm-embedded-13` (13.3.rel1) compiles clean and is what the
-  workspace's `.#otafix` shell uses, being the closest verified-working
-  version nixpkgs currently carries.
-- **`uv pip install` ignores an activated venv if `UV_PYTHON` is set** —
-  it targets that interpreter directly and fails with "externally managed"
-  against the read-only Nix store path. The workspace shell deliberately
-  does not set `UV_PYTHON` here, unlike the main `.#python` shell (which
-  has lock files that need a pinned interpreter for reproducibility; this
-  repo has none).
+  MBR-address read) — verified by actually building with it. 13.3.Rel1
+  compiles clean and is the closest verified-working version if you can't
+  get the exact CI-pinned one.
 - **MeshCore/Ripple content has been deliberately removed** from the docs
   (README, changelog) — this is Meshtastic's own branded fork now, not a
   place to re-add other companion-firmware documentation. If you're

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing
+
+Thanks for considering a contribution. This is boot-critical firmware — a
+broken bootloader can leave a device needing a hardware programmer to
+recover — so a few things here are stricter than a typical repo.
+
+## Before you start
+
+- **Read [`AGENTS.md`](./AGENTS.md) first.** It covers the board abstraction,
+  the build system split (`make` vs. the incomplete `CMakeLists.txt`), the
+  vendored submodules, and a list of known gotchas. This file covers
+  process; that one covers the code.
+- **New board support needs real hardware.** `UF2_BOARD_ID`, VID/PID, and
+  pin definitions cannot be guessed from a datasheet alone — see
+  [Adding a new board](#adding-a-new-board) below.
+- **This repo is [MIT-licensed](./LICENSE)** (originally Adafruit
+  Industries). By contributing, you agree your changes are under the same
+  license.
+
+## Building locally
+
+If you're working from a Nix-based Meshtastic dev workspace, a
+`nix develop .#otafix` style shell can provide the full toolchain and print
+these same steps. Otherwise, you need `arm-none-eabi-gcc` and Python 3
+installed yourself.
+
+```sh
+git submodule update --init --recursive   # lib/nrfx, lib/tinyusb, lib/uf2 — required, not vendored inline
+
+python3 -m venv .venv && source .venv/bin/activate
+pip install adafruit-nrfutil uritemplate requests intelhex setuptools
+
+# ARM GCC 12.3.Rel1 is what CI pins (.github/workflows/githubci.yml).
+# Newer versions (13.x verified working, 15.x does not) can hit a
+# -Werror=array-bounds false positive in bootloader_settings.c — see
+# AGENTS.md's Gotchas section before reaching for a newer toolchain.
+
+make BOARD=wiscore_rak4631_board all
+make BOARD=wiscore_rak4631_board copy-artifact   # writes _bin/<board>/
+```
+
+Board names are the directory names under `src/boards/`. `tools/build_all.py`
+builds every board and prints a pass/fail + size table — run it before
+opening a PR; it's the same check CI's board matrix does per-PR, just local.
+
+**Use `make`, not `cmake`.** `CMakeLists.txt` only has a `board.cmake` for 2
+of the 14 boards; `cmake -DBOARD=<anything else>` fails outright. Nobody
+uses the CMake path in practice.
+
+There is no lint or test suite — for a bootloader, "does it compile for
+every board" (CI's job) and real hardware testing are the correctness
+signals that exist.
+
+## Adding a new board
+
+The [README's board list](./README.md#boards-supported) says to raise an
+issue for a board you'd like supported — that's still the right first step,
+and [#4](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/issues/4)
+and
+[#5](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/issues/5)
+are open examples. To actually submit the board yourself:
+
+1. You need the physical hardware to test on — a bootloader that compiles
+   but was never flashed is not a contribution, it's a liability.
+2. Add `src/boards/<your-board>/board.h` and `board.mk`, following an
+   existing board (e.g. `src/boards/wiscore_rak4631_board`) as a template.
+3. `UF2_BOARD_ID` must follow the format in the
+   [UF2 spec](https://github.com/microsoft/uf2#files-exposed-by-bootloaders).
+   If your board has an allocated VID/PID, link to it in the PR.
+4. Confirm `make BOARD=<your-board> all` succeeds and the resulting UF2
+   actually boots the board correctly — not just compiles.
+5. The PR template has a checklist for exactly this; fill it in.
+
+## Pull requests
+
+- CI (`.github/workflows/githubci.yml`) builds every board in the matrix on
+  every PR. Branch protection on `master` requires all of those checks to
+  pass before merge.
+- Recent commit history is
+  [Conventional Commits](https://www.conventionalcommits.org/)-style
+  (`docs:`, `ci:`, `chore:`, etc.); older history (pre-fork) is looser —
+  match the newer style going forward.
+- Keep PRs scoped to one change. A board addition, a docs fix, and a CI
+  tweak are three PRs, not one.
+
+## Code of Conduct and security
+
+This project follows the
+[Meshtastic Code of Conduct](./CODE_OF_CONDUCT.md). Report security
+vulnerabilities privately per [`SECURITY.md`](./SECURITY.md) — not as a
+public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,7 @@ recover — so a few things here are stricter than a typical repo.
 
 ## Building locally
 
-If you're working from a Nix-based Meshtastic dev workspace, a
-`nix develop .#otafix` style shell can provide the full toolchain and print
-these same steps. Otherwise, you need `arm-none-eabi-gcc` and Python 3
-installed yourself.
+You need `arm-none-eabi-gcc` and Python 3 installed.
 
 ```sh
 git submodule update --init --recursive   # lib/nrfx, lib/tinyusb, lib/uf2 — required, not vendored inline

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # Meshtastic OTAFIX Bootloader
 
 [![Build](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/actions/workflows/githubci.yml/badge.svg)](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/actions/workflows/githubci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-Adafruit nRF52 bootloader with enhanced OTA DFU, forked for [Meshtastic](https://meshtastic.org) from [oltaco's OTAFIX bootloader](https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX). This is the bootloader several nRF52-based Meshtastic devices ship with, and the one the [Meshtastic Android app](https://github.com/meshtastic/Meshtastic-Android) can upgrade in-app (see [Bootloader upgrade from the Meshtastic Android app](#bootloader-upgrade-from-the-meshtastic-android-app) below).
+Adafruit nRF52 bootloader with enhanced OTA DFU, forked for [Meshtastic](https://meshtastic.org) from [oltaco's OTAFIX bootloader](https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX). This is the bootloader several nRF52-based Meshtastic devices ship with, and the one the [Meshtastic Android app](https://github.com/meshtastic/Meshtastic-Android) can upgrade in-app.
 
 Current release: **OTAFIX 2.2** — see [changelog.md](changelog.md) for version history.
+
+## Contents
+
+- [Boards supported](#boards-supported)
+- [Installation](#installation)
+- [Bootloader upgrade from the Meshtastic Android app](#bootloader-upgrade-from-the-meshtastic-android-app)
+- [Troubleshooting](#troubleshooting)
+- [Recommended OTA DFU settings](#recommended-ota-dfu-settings)
+- [Notes on Xiao NRF52840 BLE](#notes-on-xiao-nrf52840-ble)
+- [Notes on RAK4631 bootloader](#notes-on-rak4631-bootloader)
+- [Contributing](#contributing)
+- [Getting help](#getting-help)
+- [License](#license)
 
 ---
 
@@ -24,14 +38,14 @@ Current release: **OTAFIX 2.2** — see [changelog.md](changelog.md) for version
 - Seeed Studio XIAO nRF52840 BLE ([See note](#notes-on-xiao-nrf52840-ble))
 - Seeed Studio XIAO nRF52840 BLE SENSE
 
-If there is another nRF52840-based Meshtastic board you would like to see supported, please raise a GitHub issue.
+If there is another nRF52840-based Meshtastic board you would like to see supported, please [raise a GitHub issue](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/issues/new/choose) — or see [Adding a new board](./CONTRIBUTING.md#adding-a-new-board) in `CONTRIBUTING.md` if you want to submit it yourself.
 
 ---
 
 ## Installation
 
 The recommended way to install the bootloader is using the UF2 file.  
-Download the UF2 file for your board (they can be found in the releases with filenames beginning with `update-`), enter UF2 mode (usually by double pressing the reset button within 0.5s) and copy the UF2 file across.
+Download the UF2 file for your board (they can be found in the [releases](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/releases) with filenames beginning with `update-`), enter UF2 mode (usually by double pressing the reset button within 0.5s) and copy the UF2 file across.
 
 If an incorrect bootloader has been flashed to the device, a full bootloader and SoftDevice zip package will need to be flashed using ``adafruit-nrfutil``.
 
@@ -139,22 +153,20 @@ This version of the RAK4631 bootloader is based on a much newer version (0.9.2) 
 
 ---
 
-## Building locally
+## Contributing
 
-The build is `make`-based; the `CMakeLists.txt` in this repo is incomplete — only `heltec_t114` and `thinknode_m1` have a `board.cmake`, so `cmake -DBOARD=<other board>` will fail with `BOARD is not defined`-style errors. Use `make`.
+Want to build from source, add a board, or submit a fix? See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the development setup and PR
+process, and [`AGENTS.md`](./AGENTS.md) for how the codebase is put
+together.
 
-```sh
-git submodule update --init --recursive
+## Getting help
 
-python3 -m venv .venv && source .venv/bin/activate
-pip install adafruit-nrfutil uritemplate requests intelhex setuptools
+- **Questions or troubleshooting:** [Meshtastic Discussions](https://github.com/orgs/meshtastic/discussions)
+- **Bug reports and feature requests:** [open an issue](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/issues/new/choose)
+- **Security vulnerabilities:** see [`SECURITY.md`](./SECURITY.md) — please do not open a public issue
+- **General Meshtastic docs:** [meshtastic.org](https://meshtastic.org/)
 
-# ARM GCC 12.3.Rel1 is what CI pins (.github/workflows/githubci.yml).
-# Newer versions (13.x tested working, 15.x does not) can hit a
-# -Werror=array-bounds false positive in bootloader_settings.c.
+## License
 
-make BOARD=wiscore_rak4631_board all
-make BOARD=wiscore_rak4631_board copy-artifact   # writes _bin/<board>/
-```
-
-Board names are the directory names under `src/boards/`. `tools/build_all.py` builds every board and prints a pass/fail + size table — useful for checking a change against the full matrix before pushing, the same thing CI's board matrix does per-PR.
+[MIT](./LICENSE), originally Copyright (c) 2016 Adafruit Industries.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Adafruit nRF52 Bootloader Changelog
 
+OTAFIX 2.1 and 2.2 are Meshtastic's fork; everything from 0.6.2 down predates
+it and is upstream Adafruit history, kept for provenance.
+
 ## OTAFIX 2.2
 
 - Use maximum TX power for BLE: BLE TX power set to +8 for nRF52840.


### PR DESCRIPTION
## Summary

Docs pass focused on separating **usage** (README, for end users flashing a device) from **development** (CONTRIBUTING.md, for anyone building from source or adding a board) - they'd been mixed together in the README.

- **New `CONTRIBUTING.md`**: build setup (moved out of README), a concrete "adding a new board" process pointing at #4/#5 as live examples, PR/CI/branch-protection expectations, commit-style guidance.
- **README.md**: table of contents, a license badge, a License section, a Getting Help section. Build instructions replaced with a pointer to `CONTRIBUTING.md`/`AGENTS.md`.
- **`.github/ISSUE_TEMPLATE/config.yml`**: was pointing bug reporters at the **Adafruit support forum** - not caught in the earlier MeshCore-stripping pass. Now points at Meshtastic Discussions + meshtastic.org, matching `Meshtastic-Android`'s own template.
- **`bug_report.yml`**: added a Board dropdown - previously the single most important diagnostic fact for a bootloader bug wasn't asked for at all. Dropped "Windows 7."
- **PR template**: cross-links `CONTRIBUTING.md`, asks for `tools/build_all.py` / real-hardware confirmation on new boards.
- **`changelog.md`**: one-line provenance note distinguishing the OTAFIX-era (Meshtastic) entries from the pre-fork Adafruit history.
- **`AGENTS.md`**: "First read" now lists `CONTRIBUTING.md`.

## Test plan
- [x] `yq eval '.' .github/ISSUE_TEMPLATE/*.yml` - both valid
- [x] Every README TOC anchor checked against its actual header slug
- [x] No functional/code changes - docs and templates only