### PR TITLE
fix: size CURRENT.UF2 to the real installed app, not the max region

### DIFF
--- a/src/usb/msc_uf2.c
+++ b/src/usb/msc_uf2.c
@@ -223,6 +223,13 @@ void tud_msc_write10_complete_cb(uint8_t lun)
         // update App
         update_status.status_code = DFU_UPDATE_APP_COMPLETE;
 
+        // Record the real written size so bootloader_settings.bank_0_size
+        // reflects the actual app, not 0 -- ghostfat.c's CURRENT.UF2 uses
+        // this to size its dump to the real app instead of the max region.
+        // 256 mirrors ghostfat.c's UF2_FIRMWARE_BYTES_PER_SECTOR (the UF2
+        // format's fixed payload-per-block size, not board-specific).
+        update_status.app_size = _wr_state.numWritten * 256;
+
         PRINTF("Application update complete\r\n");
       }
 

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -176,6 +176,49 @@ STATIC_ASSERT(UF2_SECTORS == ((UF2_SIZE/2) / 256)); // Not a requirement ... ens
 #define UF2_FIRST_SECTOR   ((NUM_FILES + 1) * BPB_SECTORS_PER_CLUSTER) // WARNING -- code presumes each non-UF2 file content fits in single sector
 #define UF2_LAST_SECTOR    ((UF2_FIRST_SECTOR + UF2_SECTORS - 1) * BPB_SECTORS_PER_CLUSTER)
 
+// CURRENT.UF2 (the on-the-fly dump of the currently-flashed app) reports and
+// generates content sized to the REAL installed app, not the fixed max
+// TRUE_USER_FLASH_SIZE region above. Otherwise every read/write of
+// CURRENT.UF2 covers however much of the app-flash region is left over from
+// whatever previously occupied it, well past the real app+SD boundary.
+// Mirrors the size adafruit/Adafruit_nRF52_Bootloader#38 (2018) used before
+// this file's current.uf2 handling was rewritten in #128.
+static uint32_t current_flash_size(void)
+{
+  static uint32_t flash_sz = 0;
+
+  if ( flash_sz == 0 )
+  {
+    bootloader_settings_t const * boot_setting;
+    bootloader_util_settings_get(&boot_setting);
+
+    flash_sz = boot_setting->bank_0_size;
+
+    // Round up to a whole UF2 payload chunk, else the last real chunk of
+    // the app would get truncated out of CURRENT.UF2.
+    if ( flash_sz % UF2_FIRMWARE_BYTES_PER_SECTOR )
+    {
+      flash_sz = (flash_sz - (flash_sz % UF2_FIRMWARE_BYTES_PER_SECTOR)) + UF2_FIRMWARE_BYTES_PER_SECTOR;
+    }
+
+    // bank_0_size is 0 or erased-flash when the app was written by a tool
+    // that bypasses the bootloader's own settings page (e.g. a debug
+    // probe) -- fall back to the max region so CURRENT.UF2 still covers
+    // the whole possible app instead of reporting a bogus small size.
+    if ( (flash_sz == 0) || (flash_sz == 0xFFFFFFFFUL) || (flash_sz > TRUE_USER_FLASH_SIZE) )
+    {
+      flash_sz = TRUE_USER_FLASH_SIZE;
+    }
+  }
+
+  return flash_sz;
+}
+
+#define CURRENT_UF2_SECTORS  ( (current_flash_size() / UF2_FIRMWARE_BYTES_PER_SECTOR) + \
+                              ((current_flash_size() % UF2_FIRMWARE_BYTES_PER_SECTOR) ? 1 : 0))
+#define CURRENT_UF2_SIZE     (CURRENT_UF2_SECTORS * BPB_SECTOR_SIZE)
+#define CURRENT_UF2_LAST_SECTOR ((UF2_FIRST_SECTOR + CURRENT_UF2_SECTORS - 1) * BPB_SECTORS_PER_CLUSTER)
+
 #define FS_START_FAT0_SECTOR      BPB_RESERVED_SECTORS
 #define FS_START_FAT1_SECTOR      (FS_START_FAT0_SECTOR + BPB_SECTORS_PER_FAT)
 #define FS_START_ROOTDIR_SECTOR   (FS_START_FAT1_SECTOR + BPB_SECTORS_PER_FAT)
@@ -323,10 +366,11 @@ void read_block(uint32_t block_no, uint8_t *data) {
                 data[i] = 0xff;
             }
         }
+        uint32_t const current_uf2_last_sector = CURRENT_UF2_LAST_SECTOR;
         for (uint32_t i = 0; i < FAT_ENTRIES_PER_SECTOR; ++i) { // Generate the FAT chain for the firmware "file"
             uint32_t v = (sectionIdx * FAT_ENTRIES_PER_SECTOR) + i;
-            if (UF2_FIRST_SECTOR <= v && v <= UF2_LAST_SECTOR)
-                ((uint16_t *)(void *)data)[i] = v == UF2_LAST_SECTOR ? 0xffff : v + 1;
+            if (UF2_FIRST_SECTOR <= v && v <= current_uf2_last_sector)
+                ((uint16_t *)(void *)data)[i] = v == current_uf2_last_sector ? 0xffff : v + 1;
         }
     } else if (block_no < FS_START_CLUSTERS_SECTOR) { // Requested root directory sector
 
@@ -360,7 +404,7 @@ void read_block(uint32_t block_no, uint8_t *data) {
             d->updateTime       = __DOSTIME__;
             d->updateDate       = __DOSDATE__;
             d->startCluster     = startCluster & 0xFFFF;
-            d->size = (inf->content ? strlen(inf->content) : UF2_SIZE);
+            d->size = (inf->content ? strlen(inf->content) : CURRENT_UF2_SIZE);
         }
 
     } else if (block_no < BPB_TOTAL_SECTORS) {
@@ -371,13 +415,13 @@ void read_block(uint32_t block_no, uint8_t *data) {
         } else { // generate the UF2 file data on-the-fly
             sectionIdx -= NUM_FILES - 1;
             uint32_t addr = USER_FLASH_START + (sectionIdx * UF2_FIRMWARE_BYTES_PER_SECTOR);
-            if (addr < CFG_UF2_FLASH_SIZE) {
+            if (addr < USER_FLASH_START + current_flash_size()) {
                 UF2_Block *bl = (void *)data;
                 bl->magicStart0 = UF2_MAGIC_START0;
                 bl->magicStart1 = UF2_MAGIC_START1;
                 bl->magicEnd = UF2_MAGIC_END;
                 bl->blockNo = sectionIdx;
-                bl->numBlocks = UF2_SECTORS;
+                bl->numBlocks = CURRENT_UF2_SECTORS;
                 bl->targetAddr = addr;
                 bl->payloadSize = UF2_FIRMWARE_BYTES_PER_SECTOR;
                 bl->flags = UF2_FLAG_FAMILYID;


### PR DESCRIPTION
## Summary

While hardware-testing #19 (nrfx/tinyusb bump) on a real RAK4631, restoring the app via the bootloader's own `CURRENT.UF2` (a live dump of the app region, generated by `ghostfat.c`'s `read_block()`) reproducibly hung the device — even though the bytes being written back were byte-identical to what was already there. A control test confirmed this is **pre-existing**, not caused by #19: the unmodified, currently-shipped bootloader hangs the exact same way.

Digging into it turned up real history:
- `CURRENT.UF2` currently reports/generates content sized to `TRUE_USER_FLASH_SIZE` — the max possible app+SoftDevice region — regardless of how big the actually-installed app is. On the test device (RAK4631, Meshtastic 2.7.26), that's ~390KB more than the real firmware image (3728 vs 2966 UF2 blocks), padding out with whatever's physically sitting in flash past the real app+SD boundary.
- [adafruit/Adafruit_nRF52_Bootloader#38](https://github.com/adafruit/Adafruit_nRF52_Bootloader/pull/38) (2018) fixed a related `CURRENT.UF2` problem by sizing it off `bootloader_settings.bank_0_size` (the real recorded size of the currently-installed app) instead of a fixed constant. That fix has **no trace left** in the current file — it was dropped somewhere along the way, likely during [#128](https://github.com/adafruit/Adafruit_nRF52_Bootloader/pull/128)'s SoftDevice-decoupling rewrite in 2020 (whose own checklist claims `CURRENT.UF2` was tested working at the time).
- [adafruit/Adafruit_nRF52_Bootloader#201](https://github.com/adafruit/Adafruit_nRF52_Bootloader/issues/201) (2020) documents copying `CURRENT.UF2` back onto the drive as a *working* community-known recovery trick for devices stuck in DFU mode — so this round-trip is supposed to be reliable, not "expected to be flaky."

## Fix

Two commits, both required together:
1. `ghostfat.c`: restores the same idea as the 2018 fix — `current_flash_size()`, reading `bootloader_settings.bank_0_size` with the same zero/erased-flash fallback to the max region — grafted onto the current SoftDevice-decoupled code, which computes the max bound differently (`TRUE_USER_FLASH_SIZE`, not the 2018 code's constant).
2. `msc_uf2.c`: found *while testing* commit 1 — `bank_0_size` was still being recorded as 0 for any app flashed via plain UF2 drag-and-drop (as opposed to DFU-serial, which populates it correctly), because `tud_msc_write10_complete_cb()`'s app-completion branch never set `update_status.app_size` before calling `bootloader_dfu_update_process()`. Commit 1 does nothing for the common case without this.

## Test plan

- [x] `tools/build_all.py` — all 14 boards build clean
- [x] **Hardware retest of the exact `CURRENT.UF2` dump-and-restore sequence that hung before, on the same RAK4631 — confirmed fixed.** After both commits: `CURRENT.UF2` reports exactly 1518592 bytes, an exact match with the official release UF2 (previously 1908736 bytes of padding). Dumped it and copied it straight back — device rebooted in ~2 seconds and came back fully functional, versus the previous indefinite hang / 36-second-then-still-broken behavior (details in PR comments).
- [ ] Only one board (RAK4631) hardware-tested. The `bank_0_size` fix in particular is board-independent (it's in shared `usb/` code, not `src/boards/`), but broader testing before merge is still reasonable for boot-critical code like this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * UF2 application updates now accurately reflect the application’s actual size.
  * Generated update files use the appropriate storage range, reducing unnecessary file size and improving compatibility with update tools.
  * Added safe fallback behavior when application size information is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->