### PR TITLE
docs: explain the boot chain, SoftDevice, and the three update paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,18 @@ Canonical guidance for AI coding agents and maintainers working in this repo.
 
 ## First read
 
-1. `README.md` — boards supported, installation, the Meshtastic Android
-   in-app upgrade flow, troubleshooting.
-2. `CONTRIBUTING.md` — dev setup, PR process, adding a new board.
-3. `changelog.md` — OTAFIX version history (2.1/2.2 at the top; everything
+1. [README.md's "How this fits together"](./README.md#how-this-fits-together)
+   — the boot chain (MBR → this bootloader → SoftDevice → application), why
+   this repo is only the bootloader and not the Meshtastic application
+   itself, and the three ways a new image gets installed (UF2, serial DFU,
+   BLE OTA DFU). Read this before touching `main.c` or `usb/` — the
+   Architecture section below assumes it.
+2. The rest of `README.md` — boards supported, installation, the Meshtastic
+   Android in-app upgrade flow, troubleshooting.
+3. `CONTRIBUTING.md` — dev setup, PR process, adding a new board.
+4. `changelog.md` — OTAFIX version history (2.1/2.2 at the top; everything
    below predates the OTAFIX fork).
-4. The design invariants and gotchas below — do not violate them.
+5. The design invariants and gotchas below — do not violate them.
 
 ## What this is
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Current release: **OTAFIX 2.2** — see [changelog.md](changelog.md) for version
 
 ## Contents
 
+- [How this fits together](#how-this-fits-together)
 - [Boards supported](#boards-supported)
 - [Installation](#installation)
 - [Bootloader upgrade from the Meshtastic Android app](#bootloader-upgrade-from-the-meshtastic-android-app)
@@ -19,6 +20,48 @@ Current release: **OTAFIX 2.2** — see [changelog.md](changelog.md) for version
 - [Contributing](#contributing)
 - [Getting help](#getting-help)
 - [License](#license)
+
+---
+
+## How this fits together
+
+This repo builds **only the bootloader** — the small program that runs
+before anything else on the device. It does not contain the Meshtastic
+application (the LoRa mesh, BLE, and display code); that's built entirely
+separately in [`meshtastic/firmware`](https://github.com/meshtastic/firmware).
+This bootloader's job is just to start that application, or, when asked,
+replace it (or itself) with a new version.
+
+On every power-up or reset, a tiny fixed piece of code at the very start of
+flash — Nordic's **MBR** — hands off to this bootloader. From there, the
+bootloader either:
+
+- boots straight into the installed Meshtastic application, or
+- if no valid application is installed, or the user has asked for it, waits
+  for a new one.
+
+A new application image — or occasionally the bootloader itself — can be
+installed three different ways:
+
+| Method | Transport | Typical use |
+|---|---|---|
+| **UF2 drag-and-drop** | USB, appears as a drive | Manual flashing — see [Installation](#installation) |
+| **Serial DFU** | USB, appears as a serial port | Recovery, and flashing a full bootloader+SoftDevice package with `adafruit-nrfutil` — see [Installation](#installation) |
+| **BLE OTA DFU** | Bluetooth, no cable needed | The Meshtastic Android app's firmware/bootloader update, and any Nordic DFU app — see [below](#bootloader-upgrade-from-the-meshtastic-android-app) and [recommended settings](#recommended-ota-dfu-settings) |
+
+BLE OTA DFU is the only *wireless* path, which is what the "OTA" in
+"OTAFIX" refers to — and it's also the bootloader's default fallback: since
+**OTAFIX 2.0**, if no valid application is present, the device waits in BLE
+OTA mode automatically rather than risk getting stuck (see
+[Troubleshooting](#troubleshooting)).
+
+The application also relies on Nordic's **SoftDevice** — a closed-source,
+precompiled Bluetooth stack (vendored here as a hex blob under
+`lib/softdevice/`) that sits in flash alongside it. The bootloader and the
+application both call into it for BLE, so bootloader and SoftDevice
+versions are usually flashed together as a matched pair (that's why the
+[Installation](#installation) instructions below mention flashing "a full
+bootloader and SoftDevice zip package").
 
 ---
 


### PR DESCRIPTION
## Summary

Reviewing the docs after PR #14's overhaul: they cover *usage* well (how to flash, troubleshoot, board list) and give a decent file-by-file architecture breakdown in `AGENTS.md`, but never explain the underlying concepts someone new to this repo actually needs first:

- That this repo is **only the bootloader** — the Meshtastic application itself lives entirely in [`meshtastic/firmware`](https://github.com/meshtastic/firmware) and is built/flashed separately. Nothing said this plainly before.
- How the boot chain actually works (MBR → this bootloader → application), referenced only in passing as "MBR/SoftDevice handoff" in `AGENTS.md` with no explanation.
- What a **SoftDevice** even is — referenced constantly (`SD_VERSION`, `S140 6.1.1`) but never defined.
- That UF2 drag-and-drop, serial DFU, and BLE OTA DFU are **three different transports for the same job**, not three unrelated features — the README documents *how* to use each individually but never says this.

## Changes

- New `README.md` section, **How this fits together**, right after the intro (before "Boards supported"): the boot chain, the "this repo ≠ the application" split, a table of the three update paths with pointers to where each is already documented in detail, and a short SoftDevice explainer.
- `AGENTS.md`'s "First read" now points at that section first, since the Architecture section's terminology (MBR/SoftDevice handoff, DFU state machine) assumes it.

No functional changes — docs only.

## Test plan

- [x] PR title specifically describes the change
- [x] `tools/build_all.py` (or CI's board matrix) passes — unaffected by a docs-only change, verified green anyway
- [x] Proofread rendered Markdown (table, anchors, section ordering) for correctness
- [N/A] No code, board, or CI config touched
