### PR TITLE
fix: backport five upstream Adafruit fixes (boot loop, GCC 15, DFU reliability)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,12 +334,6 @@ endif
 
 CFLAGS += -DDFU_APP_DATA_RESERVED=$(DFU_APP_DATA_RESERVED)
 
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-# Fixes for gcc version 12, 13, 14 and 15.
-ifneq (,$(filter 12.% 13.% 14.% 15.%,$(shell $(CC) -dumpversion 2>/dev/null)))
-	CFLAGS += --param=min-pagesize=0
-endif
-
 #------------------------------------------------------------------------------
 # Linker Flags
 #------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -335,8 +335,8 @@ endif
 CFLAGS += -DDFU_APP_DATA_RESERVED=$(DFU_APP_DATA_RESERVED)
 
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-# Fixes for gcc version 12, 13 and 14.
-ifneq (,$(filter 12.% 13.% 14.%,$(shell $(CC) -dumpversion 2>/dev/null)))
+# Fixes for gcc version 12, 13, 14 and 15.
+ifneq (,$(filter 12.% 13.% 14.% 15.%,$(shell $(CC) -dumpversion 2>/dev/null)))
 	CFLAGS += --param=min-pagesize=0
 endif
 

--- a/lib/sdk11/components/ble/ble_services/ble_dfu/ble_dfu.c
+++ b/lib/sdk11/components/ble/ble_services/ble_dfu/ble_dfu.c
@@ -555,29 +555,35 @@ uint32_t ble_dfu_bytes_rcvd_report(ble_dfu_t * p_dfu, uint32_t num_of_firmware_b
         return NRF_ERROR_INVALID_STATE;
     }
 
-    ble_gatts_hvx_params_t hvx_params;
-    uint16_t               index = 0;
+    uint32_t err_code;
+	do {
 
-    // Encode the Op Code.
-    m_notif_buffer[index++] = OP_CODE_RESPONSE;
+        ble_gatts_hvx_params_t hvx_params;
+        uint16_t               index = 0;
+    
+        // Encode the Op Code.
+        m_notif_buffer[index++] = OP_CODE_RESPONSE;
+    
+        // Encode the Reqest Op Code.
+        m_notif_buffer[index++] = OP_CODE_IMAGE_SIZE_REQ;
+    
+        // Encode the Response Value.
+        m_notif_buffer[index++] = (uint8_t)BLE_DFU_RESP_VAL_SUCCESS;
+    
+        index += uint32_encode(num_of_firmware_bytes_rcvd, &m_notif_buffer[index]);
+    
+        memset(&hvx_params, 0, sizeof(hvx_params));
+    
+        hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
+        hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
+        hvx_params.offset = 0;
+        hvx_params.p_len  = &index;
+        hvx_params.p_data = m_notif_buffer;
+		
+        err_code = sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    } while (err_code == NRF_ERROR_RESOURCES);	
 
-    // Encode the Reqest Op Code.
-    m_notif_buffer[index++] = OP_CODE_IMAGE_SIZE_REQ;
-
-    // Encode the Response Value.
-    m_notif_buffer[index++] = (uint8_t)BLE_DFU_RESP_VAL_SUCCESS;
-
-    index += uint32_encode(num_of_firmware_bytes_rcvd, &m_notif_buffer[index]);
-
-    memset(&hvx_params, 0, sizeof(hvx_params));
-
-    hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
-    hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
-    hvx_params.offset = 0;
-    hvx_params.p_len  = &index;
-    hvx_params.p_data = m_notif_buffer;
-
-    return sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    return err_code;	
 }
 
 
@@ -593,22 +599,28 @@ uint32_t ble_dfu_pkts_rcpt_notify(ble_dfu_t * p_dfu, uint32_t num_of_firmware_by
         return NRF_ERROR_INVALID_STATE;
     }
 
-    ble_gatts_hvx_params_t hvx_params;
-    uint16_t               index = 0;
+    uint32_t err_code;
+	do {
 
-    m_notif_buffer[index++] = OP_CODE_PKT_RCPT_NOTIF;
+        ble_gatts_hvx_params_t hvx_params;
+        uint16_t               index = 0;
+    
+        m_notif_buffer[index++] = OP_CODE_PKT_RCPT_NOTIF;
+    
+        index += uint32_encode(num_of_firmware_bytes_rcvd, &m_notif_buffer[index]);
+    
+        memset(&hvx_params, 0, sizeof(hvx_params));
+    
+        hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
+        hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
+        hvx_params.offset = 0;
+        hvx_params.p_len  = &index;
+        hvx_params.p_data = m_notif_buffer;
 
-    index += uint32_encode(num_of_firmware_bytes_rcvd, &m_notif_buffer[index]);
+        err_code = sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    } while (err_code == NRF_ERROR_RESOURCES);	
 
-    memset(&hvx_params, 0, sizeof(hvx_params));
-
-    hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
-    hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
-    hvx_params.offset = 0;
-    hvx_params.p_len  = &index;
-    hvx_params.p_data = m_notif_buffer;
-
-    return sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    return err_code;	
 }
 
 
@@ -626,24 +638,30 @@ uint32_t ble_dfu_response_send(ble_dfu_t         * p_dfu,
         return NRF_ERROR_INVALID_STATE;
     }
 
-    ble_gatts_hvx_params_t hvx_params;
-    uint16_t               index = 0;
+    uint32_t err_code;
+	do {
 
-    m_notif_buffer[index++] = OP_CODE_RESPONSE;
+        ble_gatts_hvx_params_t hvx_params;
+        uint16_t               index = 0;
+    
+        m_notif_buffer[index++] = OP_CODE_RESPONSE;
+    
+        // Encode the Request Op code
+        m_notif_buffer[index++] = (uint8_t)dfu_proc;
+    
+        // Encode the Response Value.
+        m_notif_buffer[index++] = (uint8_t)resp_val;
+    
+        memset(&hvx_params, 0, sizeof(hvx_params));
+    
+        hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
+        hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
+        hvx_params.offset = 0;
+        hvx_params.p_len  = &index;
+        hvx_params.p_data = m_notif_buffer;
+    
+        err_code = sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    } while (err_code == NRF_ERROR_RESOURCES);
 
-    // Encode the Request Op code
-    m_notif_buffer[index++] = (uint8_t)dfu_proc;
-
-    // Encode the Response Value.
-    m_notif_buffer[index++] = (uint8_t)resp_val;
-
-    memset(&hvx_params, 0, sizeof(hvx_params));
-
-    hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
-    hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
-    hvx_params.offset = 0;
-    hvx_params.p_len  = &index;
-    hvx_params.p_data = m_notif_buffer;
-
-    return sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    return err_code;	
 }

--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c
@@ -42,6 +42,10 @@ void bootloader_util_settings_get(const bootloader_settings_t ** pp_bootloader_s
 
 void bootloader_mbr_addrs_populate(void)
 {
+#if defined(__GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
   if (*(const uint32_t *)MBR_BOOTLOADER_ADDR == 0xFFFFFFFF)
   {
     nrfx_nvmc_word_write(MBR_BOOTLOADER_ADDR, BOOTLOADER_REGION_START);
@@ -51,4 +55,7 @@ void bootloader_mbr_addrs_populate(void)
   {
     nrfx_nvmc_word_write(MBR_PARAM_PAGE_ADDR, BOOTLOADER_MBR_PARAMS_PAGE_ADDRESS);
   }
+#if defined(__GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 }

--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader_util.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader_util.c
@@ -32,6 +32,12 @@
 #if defined ( __CC_ARM )
 __asm static void bootloader_util_reset(uint32_t start_addr)
 {
+    MOVS  R5, #0x00             ; R5 = 0
+    MSR   CONTROL, R5           ; Clear CONTROL
+    MSR   PRIMASK, R5           ; Clear PRIMASK
+    MSR   BASEPRI, R5           ; Clear BASEPRI
+    MSR   FAULTMASK, R5         ; Clear FAULTMASK
+
     LDR   R5, [R0]              ; Get App initial MSP for bootloader.
     MSR   MSP, R5               ; Set the main stack pointer to the applications MSP.
     LDR   R0, [R0, #0x04]       ; Load Reset handler into R0. This will be first argument to branch instruction (BX).
@@ -69,6 +75,12 @@ static inline void bootloader_util_reset (uint32_t start_addr) __attribute__ ((o
 static inline void bootloader_util_reset(uint32_t start_addr)
 {
     __asm volatile(
+        "movs  r5, #0x00\t\n"           // R5 = 0
+        "msr   control, r5\t\n"         // Clear CONTROL
+        "msr   primask, r5\t\n"         // Clear PRIMASK
+        "msr   basepri, r5\t\n"         // Clear BASEPRI
+        "msr   faultmask, r5\t\n"       // Clear FAULTMASK
+
         "ldr   r0, [%0]\t\n"            // Get App initial MSP for bootloader.
         "msr   msp, r0\t\n"             // Set the main stack pointer to the applications MSP.
         "ldr   r0, [%0, #0x04]\t\n"     // Load Reset handler into R0.
@@ -108,7 +120,13 @@ static inline void bootloader_util_reset(uint32_t start_addr)
 #elif defined ( __ICCARM__ )
 static inline void bootloader_util_reset(uint32_t start_addr)
 {
-    asm("ldr   r5, [%0]\n"                    // Get App initial MSP for bootloader.
+    asm("movs  r5, #0x00\n"                   // R5 = 0
+        "msr   control, r5\n"                 // Clear CONTROL
+        "msr   primask, r5\n"                 // Clear PRIMASK
+        "msr   basepri, r5\n"                 // Clear BASEPRI
+        "msr   faultmask, r5\n"               // Clear FAULTMASK
+
+        "ldr   r5, [%0]\n"                    // Get App initial MSP for bootloader.
         "msr   msp, r5\n"                     // Set the main stack pointer to the applications MSP.
         "ldr   r0, [%0, #0x04]\n"             // Load Reset handler into R0.
 

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -40,9 +40,16 @@
 //
 //--------------------------------------------------------------------+
 
+// Add nonstring attribute if supported to avoid errors in GCC 15
+#ifdef __has_attribute
+    #define __NONSTRING__ __attribute__((nonstring))
+#else
+    #define __NONSTRING__
+#endif
+
 typedef struct {
     uint8_t JumpInstruction[3];
-    uint8_t OEMInfo[8];
+    uint8_t OEMInfo[8] __NONSTRING__;
     uint16_t SectorSize;
     uint8_t SectorsPerCluster;
     uint16_t ReservedSectors;
@@ -59,8 +66,8 @@ typedef struct {
     uint8_t Reserved;
     uint8_t ExtendedBootSig;
     uint32_t VolumeSerialNumber;
-    uint8_t VolumeLabel[11];
-    uint8_t FilesystemIdentifier[8];
+    uint8_t VolumeLabel[11] __NONSTRING__;
+    uint8_t FilesystemIdentifier[8] __NONSTRING__;
 } __attribute__((packed)) FAT_BootBlock;
 
 typedef struct {
@@ -81,7 +88,7 @@ typedef struct {
 STATIC_ASSERT(sizeof(DirEntry) == 32);
 
 struct TextFile {
-  char const name[11];
+  char const name[11] __NONSTRING__;
   char const *content;
 };
 

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -41,18 +41,18 @@
 //--------------------------------------------------------------------+
 
 // Add nonstring attribute if supported to avoid errors in GCC 15
-#ifdef __has_attribute
-    #define __NONSTRING__ __attribute__((nonstring))
+#if defined(__has_attribute) && __has_attribute(nonstring)
+  #define ATTR_NONSTRING __attribute__((nonstring))
 #else
-    #define __NONSTRING__
+  #define ATTR_NONSTRING
 #endif
 
 typedef struct {
     uint8_t JumpInstruction[3];
-    uint8_t OEMInfo[8] __NONSTRING__;
-    uint16_t SectorSize;
-    uint8_t SectorsPerCluster;
-    uint16_t ReservedSectors;
+  uint8_t  OEMInfo[8] ATTR_NONSTRING;
+  uint16_t SectorSize;
+  uint8_t  SectorsPerCluster;
+  uint16_t ReservedSectors;
     uint8_t FATCopies;
     uint16_t RootDirectoryEntries;
     uint16_t TotalSectors16;
@@ -66,8 +66,8 @@ typedef struct {
     uint8_t Reserved;
     uint8_t ExtendedBootSig;
     uint32_t VolumeSerialNumber;
-    uint8_t VolumeLabel[11] __NONSTRING__;
-    uint8_t FilesystemIdentifier[8] __NONSTRING__;
+    uint8_t  VolumeLabel[11] ATTR_NONSTRING;
+    uint8_t  FilesystemIdentifier[8] ATTR_NONSTRING;
 } __attribute__((packed)) FAT_BootBlock;
 
 typedef struct {
@@ -88,8 +88,8 @@ typedef struct {
 STATIC_ASSERT(sizeof(DirEntry) == 32);
 
 struct TextFile {
-  char const name[11] __NONSTRING__;
-  char const *content;
+  const char  name[11] ATTR_NONSTRING;
+  const char *content;
 };
 
 


### PR DESCRIPTION
Closes the near-term half of #25. Stacked on #24 (base is that branch; GitHub will retarget to `master` when it merges).

## What's backported

Five commits cherry-picked from `adafruit/Adafruit_nRF52_Bootloader` mainline (post-0.9.2 work our oltaco-lineage base never received), original authorship preserved:

| Upstream | Fix | Risk notes |
|---|---|---|
| `6250be4` (Tomasz Duda) | Boot loop from wrong REGOUT0 read | `src/boards/boards.c` init code; applied clean |
| `d435d66` (Willow Herring) | GCC 15 build errors (Makefile version filter + ghostfat.c) | Prophylactic — CI pins GCC 12.3; verified no regression on 13.3 |
| `6b24be5` (hathach) | `-Warray-bounds` pragmas in `bootloader_settings.c` + `ATTR_NOSTRING` cleanup; removes the global `--param=min-pagesize=0` workaround | **This is the exact GCC-15 fragility our AGENTS.md Gotchas documents as known-but-unpatched.** The `bootloader_settings.c` change is a pure `#pragma GCC diagnostic` wrap — zero behavior change to the MBR-address flash reads |
| `d0f13ea` (E. J. Tagle) | Clear CONTROL/PRIMASK/BASEPRI/FAULTMASK before jumping to the application (was rarely causing lockups) | Self-contained asm prologue in `bootloader_util.c`; our copy of the file was byte-identical to upstream's parent |
| `2910556` (E. J. Tagle) | Wait for BLE notification-queue room instead of silently dropping DFU completion notifications | `ble_dfu.c` — our copy was only lightly diverged (27 lines); applied without conflict and compiles clean, no dependency on the rest of ejtagle's series |

**Deferred (tracked in #25):** `e1ea1c6` (flash-operation-queue wait) — built around `dfu_dual_bank.c`, which our tree predates, plus deep `dfu_single_bank.c` changes where OTAFIX's lazy-erase rework lives.

## Conflicts resolved

- `Makefile` ×2, both trivial: kept our `2>/dev/null` (no `NULL_DEVICE` var in our tree) while adding `15.%` to the GCC version filter; then removed that whole block per `6b24be5`'s intent (pragmas replace the global param).

## Testing

- Local builds pass on GCC 13.3 for `wiscore_rak4631_board`, `heltec_t114`, `t1000_e`, `xiao_nrf52840_ble` (representative: RAK, display board, Seeed 7.3.0-SoftDevice, XIAO).
- **Needs hardware validation before merge** — especially `d0f13ea` (app-jump path) and `2910556` (BLE DFU path). A RAK4631 flash + OTA DFU round-trip covers both.

## Test plan
- [ ] CI green on all 17 boards
- [ ] RAK4631: flash bootloader, verify app boots (covers `d0f13ea`, `6250be4`)
- [ ] RAK4631: BLE OTA DFU round-trip (covers `2910556`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth DFU notification reliability by retrying when temporary resources are unavailable.
  * Fixed bootloader reset handling to ensure applications start with a clean processor state.
  * Prevented unnecessary reset loops during board voltage configuration.
  * Improved compatibility with newer GCC compiler versions and reduced related build warnings.
* **Reliability**
  * Enhanced flash and bootloader initialization behavior for more consistent device startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->