### PR TITLE
docs: OTAFIX 2.3 changelog entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Canonical guidance for AI coding agents and maintainers working in this repo.
 2. The rest of `README.md` — boards supported, installation, the Meshtastic
    Android in-app upgrade flow, troubleshooting.
 3. `CONTRIBUTING.md` — dev setup, PR process, adding a new board.
-4. `changelog.md` — OTAFIX version history (2.1/2.2 at the top; everything
+4. `changelog.md` — OTAFIX version history (2.1–2.3 at the top; everything
    below predates the OTAFIX fork).
 5. The design invariants and gotchas below — do not violate them.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Adafruit nRF52 bootloader with enhanced OTA DFU, forked for [Meshtastic](https://meshtastic.org) from [oltaco's OTAFIX bootloader](https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX). This is the bootloader several nRF52-based Meshtastic devices ship with, and the one the [Meshtastic Android app](https://github.com/meshtastic/Meshtastic-Android) can upgrade in-app.
 
-Current release: **OTAFIX 2.2** — see [changelog.md](changelog.md) for version history.
+Current release: **OTAFIX 2.3** — see [changelog.md](changelog.md) for version history.
 
 ## Contents
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,21 @@
 # Adafruit nRF52 Bootloader Changelog
 
-OTAFIX 2.1 and 2.2 are Meshtastic's fork; everything from 0.6.2 down predates
+OTAFIX 2.1–2.3 are Meshtastic's fork; everything from 0.6.2 down predates
 it and is upstream Adafruit history, kept for provenance.
+
+## OTAFIX 2.3
+
+- New boards: Heltec T096, Heltec T1, RAK 3401 (merged from oltaco's upstream, which calls this same board-support work "OTAFIX 2.3" too).
+- `screen.c` refactored to a display-size-agnostic layout (macro-based bar/text positions instead of hardcoded pixel offsets) — no behavior change for existing boards, needed for the new boards' smaller displays.
+- ST7735 display controller support, alongside the existing ST7789 path.
+- Backported five upstream Adafruit fixes, hardware-validated on a RAK4631:
+  - Boot loop from a wrong REGOUT0 read.
+  - GCC 15 build errors (Makefile version filter, `ghostfat.c`).
+  - `-Werror=array-bounds` false positive in `bootloader_settings.c`, replaced with a scoped pragma instead of the previous repo-wide `--param=min-pagesize=0` workaround.
+  - Clear CONTROL/PRIMASK/BASEPRI/FAULTMASK before jumping to the application — was rarely causing lockups.
+  - Wait for BLE notification-queue room instead of silently dropping DFU completion notifications.
+- Fixed a latent out-of-bounds write in `screen.c`'s `print()`: it drew a glyph before checking whether it fit on screen, rather than after. Not reachable on any current board, but a real hazard for future `board.h` layouts.
+- `AGENTS.md` gotcha: flashing the bootloader+SoftDevice package over serial DFU zeros `bank_0`, so the device intentionally comes up in BLE-OTA wait mode instead of the app on the next boot — not a brick.
 
 ## OTAFIX 2.2
 


### PR DESCRIPTION
Adds the changelog entry for everything merged since the last release (`0.9.2-OTAFIX2.2-BP1.4`, cut at 18c3dc5): #24 (RAK3401/Heltec T096/T1 board support, screen.c refactor, review fixes), #26 (five hardware-validated Adafruit backports), #27 (AGENTS.md gotcha docs). Bumps the "current release" pointer in README.md and AGENTS.md from 2.2 to 2.3.

No code changes. Will cut the `0.9.2-OTAFIX2.3-BP1.5` tag/release from `master` once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reference OTAFIX 2.3 as the current release.
  * Expanded the changelog with OTAFIX 2.3 release notes, including supported boards, display improvements, bug fixes, and serial DFU boot behavior.
  * Clarified the history and scope of OTAFIX versions 2.1–2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->