### PR TITLE
fix: backport five targeted fixes from adafruit mainline (#25)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,13 +129,14 @@ itself; a human has to edit it too.
 
 ## Gotchas
 
-- **ARM GCC version matters.** CI pins exactly `12.3.Rel1`. Much newer
-  toolchains (verified: 15.2.Rel1) fail with `-Werror=array-bounds` in
-  `lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c`
-  (a false positive from newer GCC's stricter analysis of a fixed
-  MBR-address read) — verified by actually building with it. 13.3.Rel1
+- **ARM GCC version matters.** CI pins exactly `12.3.Rel1`; 13.3.Rel1 also
   compiles clean and is the closest verified-working version if you can't
-  get the exact CI-pinned one.
+  get the exact CI-pinned one. GCC 15 used to fail with
+  `-Werror=array-bounds` in
+  `lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c`
+  (a false positive on a fixed MBR-address read); Adafruit's fix
+  (`6b24be5`, a localised `#pragma GCC diagnostic`) is backported, but
+  nobody has rebuilt here with GCC 15 since — if you do, update this note.
 - **MeshCore/Ripple content has been deliberately removed** from the docs
   (README, changelog) — this is Meshtastic's own branded fork now, not a
   place to re-add other companion-firmware documentation. If you're

--- a/Makefile
+++ b/Makefile
@@ -334,12 +334,6 @@ endif
 
 CFLAGS += -DDFU_APP_DATA_RESERVED=$(DFU_APP_DATA_RESERVED)
 
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-# Fixes for gcc version 12, 13, 14 and 15.
-ifneq (,$(filter 12.% 13.% 14.% 15.%,$(shell $(CC) -dumpversion 2>/dev/null)))
-	CFLAGS += --param=min-pagesize=0
-endif
-
 #------------------------------------------------------------------------------
 # Linker Flags
 #------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -335,8 +335,8 @@ endif
 CFLAGS += -DDFU_APP_DATA_RESERVED=$(DFU_APP_DATA_RESERVED)
 
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-# Fixes for gcc version 12, 13 and 14.
-ifneq (,$(filter 12.% 13.% 14.%,$(shell $(CC) -dumpversion 2>/dev/null)))
+# Fixes for gcc version 12, 13, 14 and 15.
+ifneq (,$(filter 12.% 13.% 14.% 15.%,$(shell $(CC) -dumpversion 2>/dev/null)))
 	CFLAGS += --param=min-pagesize=0
 endif
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,14 @@
 OTAFIX 2.1 and 2.2 are Meshtastic's fork; everything from 0.6.2 down predates
 it and is upstream Adafruit history, kept for provenance.
 
+## Unreleased
+
+- Backported from Adafruit mainline (0.10.0/0.11.0 era; see #25):
+  - Fix boot loop caused by reading the wrong value from `REGOUT0`.
+  - Clear pending interrupts and exceptions before jumping to the application (rare lockups).
+  - Wait for BLE notification-queue room instead of dropping DFU completion notifications.
+  - GCC 15 build fixes (`Makefile`, `ghostfat.c`, `bootloader_settings.c`).
+
 ## OTAFIX 2.2
 
 - Use maximum TX power for BLE: BLE TX power set to +8 for nRF52840.

--- a/lib/sdk11/components/ble/ble_services/ble_dfu/ble_dfu.c
+++ b/lib/sdk11/components/ble/ble_services/ble_dfu/ble_dfu.c
@@ -555,29 +555,35 @@ uint32_t ble_dfu_bytes_rcvd_report(ble_dfu_t * p_dfu, uint32_t num_of_firmware_b
         return NRF_ERROR_INVALID_STATE;
     }
 
-    ble_gatts_hvx_params_t hvx_params;
-    uint16_t               index = 0;
+    uint32_t err_code;
+	do {
 
-    // Encode the Op Code.
-    m_notif_buffer[index++] = OP_CODE_RESPONSE;
+        ble_gatts_hvx_params_t hvx_params;
+        uint16_t               index = 0;
+    
+        // Encode the Op Code.
+        m_notif_buffer[index++] = OP_CODE_RESPONSE;
+    
+        // Encode the Reqest Op Code.
+        m_notif_buffer[index++] = OP_CODE_IMAGE_SIZE_REQ;
+    
+        // Encode the Response Value.
+        m_notif_buffer[index++] = (uint8_t)BLE_DFU_RESP_VAL_SUCCESS;
+    
+        index += uint32_encode(num_of_firmware_bytes_rcvd, &m_notif_buffer[index]);
+    
+        memset(&hvx_params, 0, sizeof(hvx_params));
+    
+        hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
+        hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
+        hvx_params.offset = 0;
+        hvx_params.p_len  = &index;
+        hvx_params.p_data = m_notif_buffer;
+		
+        err_code = sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    } while (err_code == NRF_ERROR_RESOURCES);	
 
-    // Encode the Reqest Op Code.
-    m_notif_buffer[index++] = OP_CODE_IMAGE_SIZE_REQ;
-
-    // Encode the Response Value.
-    m_notif_buffer[index++] = (uint8_t)BLE_DFU_RESP_VAL_SUCCESS;
-
-    index += uint32_encode(num_of_firmware_bytes_rcvd, &m_notif_buffer[index]);
-
-    memset(&hvx_params, 0, sizeof(hvx_params));
-
-    hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
-    hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
-    hvx_params.offset = 0;
-    hvx_params.p_len  = &index;
-    hvx_params.p_data = m_notif_buffer;
-
-    return sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    return err_code;	
 }
 
 
@@ -593,22 +599,28 @@ uint32_t ble_dfu_pkts_rcpt_notify(ble_dfu_t * p_dfu, uint32_t num_of_firmware_by
         return NRF_ERROR_INVALID_STATE;
     }
 
-    ble_gatts_hvx_params_t hvx_params;
-    uint16_t               index = 0;
+    uint32_t err_code;
+	do {
 
-    m_notif_buffer[index++] = OP_CODE_PKT_RCPT_NOTIF;
+        ble_gatts_hvx_params_t hvx_params;
+        uint16_t               index = 0;
+    
+        m_notif_buffer[index++] = OP_CODE_PKT_RCPT_NOTIF;
+    
+        index += uint32_encode(num_of_firmware_bytes_rcvd, &m_notif_buffer[index]);
+    
+        memset(&hvx_params, 0, sizeof(hvx_params));
+    
+        hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
+        hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
+        hvx_params.offset = 0;
+        hvx_params.p_len  = &index;
+        hvx_params.p_data = m_notif_buffer;
 
-    index += uint32_encode(num_of_firmware_bytes_rcvd, &m_notif_buffer[index]);
+        err_code = sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    } while (err_code == NRF_ERROR_RESOURCES);	
 
-    memset(&hvx_params, 0, sizeof(hvx_params));
-
-    hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
-    hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
-    hvx_params.offset = 0;
-    hvx_params.p_len  = &index;
-    hvx_params.p_data = m_notif_buffer;
-
-    return sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    return err_code;	
 }
 
 
@@ -626,24 +638,30 @@ uint32_t ble_dfu_response_send(ble_dfu_t         * p_dfu,
         return NRF_ERROR_INVALID_STATE;
     }
 
-    ble_gatts_hvx_params_t hvx_params;
-    uint16_t               index = 0;
+    uint32_t err_code;
+	do {
 
-    m_notif_buffer[index++] = OP_CODE_RESPONSE;
+        ble_gatts_hvx_params_t hvx_params;
+        uint16_t               index = 0;
+    
+        m_notif_buffer[index++] = OP_CODE_RESPONSE;
+    
+        // Encode the Request Op code
+        m_notif_buffer[index++] = (uint8_t)dfu_proc;
+    
+        // Encode the Response Value.
+        m_notif_buffer[index++] = (uint8_t)resp_val;
+    
+        memset(&hvx_params, 0, sizeof(hvx_params));
+    
+        hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
+        hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
+        hvx_params.offset = 0;
+        hvx_params.p_len  = &index;
+        hvx_params.p_data = m_notif_buffer;
+    
+        err_code = sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    } while (err_code == NRF_ERROR_RESOURCES);
 
-    // Encode the Request Op code
-    m_notif_buffer[index++] = (uint8_t)dfu_proc;
-
-    // Encode the Response Value.
-    m_notif_buffer[index++] = (uint8_t)resp_val;
-
-    memset(&hvx_params, 0, sizeof(hvx_params));
-
-    hvx_params.handle = p_dfu->dfu_ctrl_pt_handles.value_handle;
-    hvx_params.type   = BLE_GATT_HVX_NOTIFICATION;
-    hvx_params.offset = 0;
-    hvx_params.p_len  = &index;
-    hvx_params.p_data = m_notif_buffer;
-
-    return sd_ble_gatts_hvx(p_dfu->conn_handle, &hvx_params);
+    return err_code;	
 }

--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c
@@ -42,6 +42,10 @@ void bootloader_util_settings_get(const bootloader_settings_t ** pp_bootloader_s
 
 void bootloader_mbr_addrs_populate(void)
 {
+#if defined(__GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
   if (*(const uint32_t *)MBR_BOOTLOADER_ADDR == 0xFFFFFFFF)
   {
     nrfx_nvmc_word_write(MBR_BOOTLOADER_ADDR, BOOTLOADER_REGION_START);
@@ -51,4 +55,7 @@ void bootloader_mbr_addrs_populate(void)
   {
     nrfx_nvmc_word_write(MBR_PARAM_PAGE_ADDR, BOOTLOADER_MBR_PARAMS_PAGE_ADDRESS);
   }
+#if defined(__GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 }

--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader_util.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader_util.c
@@ -32,6 +32,12 @@
 #if defined ( __CC_ARM )
 __asm static void bootloader_util_reset(uint32_t start_addr)
 {
+    MOVS  R5, #0x00             ; R5 = 0
+    MSR   CONTROL, R5           ; Clear CONTROL
+    MSR   PRIMASK, R5           ; Clear PRIMASK
+    MSR   BASEPRI, R5           ; Clear BASEPRI
+    MSR   FAULTMASK, R5         ; Clear FAULTMASK
+
     LDR   R5, [R0]              ; Get App initial MSP for bootloader.
     MSR   MSP, R5               ; Set the main stack pointer to the applications MSP.
     LDR   R0, [R0, #0x04]       ; Load Reset handler into R0. This will be first argument to branch instruction (BX).
@@ -69,6 +75,12 @@ static inline void bootloader_util_reset (uint32_t start_addr) __attribute__ ((o
 static inline void bootloader_util_reset(uint32_t start_addr)
 {
     __asm volatile(
+        "movs  r5, #0x00\t\n"           // R5 = 0
+        "msr   control, r5\t\n"         // Clear CONTROL
+        "msr   primask, r5\t\n"         // Clear PRIMASK
+        "msr   basepri, r5\t\n"         // Clear BASEPRI
+        "msr   faultmask, r5\t\n"       // Clear FAULTMASK
+
         "ldr   r0, [%0]\t\n"            // Get App initial MSP for bootloader.
         "msr   msp, r0\t\n"             // Set the main stack pointer to the applications MSP.
         "ldr   r0, [%0, #0x04]\t\n"     // Load Reset handler into R0.
@@ -108,7 +120,13 @@ static inline void bootloader_util_reset(uint32_t start_addr)
 #elif defined ( __ICCARM__ )
 static inline void bootloader_util_reset(uint32_t start_addr)
 {
-    asm("ldr   r5, [%0]\n"                    // Get App initial MSP for bootloader.
+    asm("movs  r5, #0x00\n"                   // R5 = 0
+        "msr   control, r5\n"                 // Clear CONTROL
+        "msr   primask, r5\n"                 // Clear PRIMASK
+        "msr   basepri, r5\n"                 // Clear BASEPRI
+        "msr   faultmask, r5\n"               // Clear FAULTMASK
+
+        "ldr   r5, [%0]\n"                    // Get App initial MSP for bootloader.
         "msr   msp, r5\n"                     // Set the main stack pointer to the applications MSP.
         "ldr   r0, [%0, #0x04]\n"             // Load Reset handler into R0.
 

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -40,9 +40,16 @@
 //
 //--------------------------------------------------------------------+
 
+// Add nonstring attribute if supported to avoid errors in GCC 15
+#ifdef __has_attribute
+    #define __NONSTRING__ __attribute__((nonstring))
+#else
+    #define __NONSTRING__
+#endif
+
 typedef struct {
     uint8_t JumpInstruction[3];
-    uint8_t OEMInfo[8];
+    uint8_t OEMInfo[8] __NONSTRING__;
     uint16_t SectorSize;
     uint8_t SectorsPerCluster;
     uint16_t ReservedSectors;
@@ -59,8 +66,8 @@ typedef struct {
     uint8_t Reserved;
     uint8_t ExtendedBootSig;
     uint32_t VolumeSerialNumber;
-    uint8_t VolumeLabel[11];
-    uint8_t FilesystemIdentifier[8];
+    uint8_t VolumeLabel[11] __NONSTRING__;
+    uint8_t FilesystemIdentifier[8] __NONSTRING__;
 } __attribute__((packed)) FAT_BootBlock;
 
 typedef struct {
@@ -81,7 +88,7 @@ typedef struct {
 STATIC_ASSERT(sizeof(DirEntry) == 32);
 
 struct TextFile {
-  char const name[11];
+  char const name[11] __NONSTRING__;
   char const *content;
 };
 

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -41,18 +41,18 @@
 //--------------------------------------------------------------------+
 
 // Add nonstring attribute if supported to avoid errors in GCC 15
-#ifdef __has_attribute
-    #define __NONSTRING__ __attribute__((nonstring))
+#if defined(__has_attribute) && __has_attribute(nonstring)
+  #define ATTR_NONSTRING __attribute__((nonstring))
 #else
-    #define __NONSTRING__
+  #define ATTR_NONSTRING
 #endif
 
 typedef struct {
     uint8_t JumpInstruction[3];
-    uint8_t OEMInfo[8] __NONSTRING__;
-    uint16_t SectorSize;
-    uint8_t SectorsPerCluster;
-    uint16_t ReservedSectors;
+  uint8_t  OEMInfo[8] ATTR_NONSTRING;
+  uint16_t SectorSize;
+  uint8_t  SectorsPerCluster;
+  uint16_t ReservedSectors;
     uint8_t FATCopies;
     uint16_t RootDirectoryEntries;
     uint16_t TotalSectors16;
@@ -66,8 +66,8 @@ typedef struct {
     uint8_t Reserved;
     uint8_t ExtendedBootSig;
     uint32_t VolumeSerialNumber;
-    uint8_t VolumeLabel[11] __NONSTRING__;
-    uint8_t FilesystemIdentifier[8] __NONSTRING__;
+    uint8_t  VolumeLabel[11] ATTR_NONSTRING;
+    uint8_t  FilesystemIdentifier[8] ATTR_NONSTRING;
 } __attribute__((packed)) FAT_BootBlock;
 
 typedef struct {
@@ -88,8 +88,8 @@ typedef struct {
 STATIC_ASSERT(sizeof(DirEntry) == 32);
 
 struct TextFile {
-  char const name[11] __NONSTRING__;
-  char const *content;
+  const char  name[11] ATTR_NONSTRING;
+  const char *content;
 };
 
 


### PR DESCRIPTION
## Checklist

- [x] PR title specifically describes the change
- [x] `tools/build_all.py` (or CI's board matrix) passes — 14/14 locally with 13.3.Rel1
- [ ] Tested on real hardware (RAK4631) — draft until then

-----------

## Description of Change

The near-term half of #25: cherry-picks (`-x`) of the isolated Adafruit mainline fixes, in the order listed there.

- `6250be4` fix boot loop due to wrong value read from REGOUT0
- `d435d66` GCC 15 build errors (Makefile + ghostfat.c) — conflict was the gcc-version filter line only; kept our `2>/dev/null` since we have no `NULL_DEVICE` var
- `6b24be5` `-Warray-bounds` pragma in `bootloader_settings.c` + `ATTR_NOSTRING` — removes the Makefile gcc-version block entirely, as mainline did
- `d0f13ea` clear pending interrupts/exceptions before jumping to the app
- `2910556` wait for BLE notification-queue room instead of dropping DFU completion notifications — applied clean to our `ble_dfu.c`

Plus a docs commit: changelog `Unreleased` section and the AGENTS.md GCC gotcha rewritten to say the fix is in (not re-verified against GCC 15 here — only 13.3 available in the nix shell).

`e1ea1c6` (flash-op-queue wait) left out as deferred per #25.

Hardware test plan before un-drafting, on RAK4631: boot into app, USB UF2 flash, BLE OTA DFU via Android app, `CURRENT.UF2` dump-and-restore (the #20 regression check).