### PR TITLE
fix: size CURRENT.UF2 from the app start, not from every block written

### DIFF
--- a/src/usb/msc_uf2.c
+++ b/src/usb/msc_uf2.c
@@ -223,12 +223,15 @@ void tud_msc_write10_complete_cb(uint8_t lun)
         // update App
         update_status.status_code = DFU_UPDATE_APP_COMPLETE;
 
-        // Record the real written size so bootloader_settings.bank_0_size
+        // Record the real app span so bootloader_settings.bank_0_size
         // reflects the actual app, not 0 -- ghostfat.c's CURRENT.UF2 uses
-        // this to size its dump to the real app instead of the max region.
-        // 256 mirrors ghostfat.c's UF2_FIRMWARE_BYTES_PER_SECTOR (the UF2
-        // format's fixed payload-per-block size, not board-specific).
-        update_status.app_size = _wr_state.numWritten * 256;
+        // this to size its dump. Measured from DFU_BANK_0_REGION_START like
+        // serial/OTA DFU do, so a CURRENT.UF2 restore (which also carries
+        // the SoftDevice blocks) does not overcount.
+        if ( _wr_state.appEnd > DFU_BANK_0_REGION_START )
+        {
+          update_status.app_size = _wr_state.appEnd - DFU_BANK_0_REGION_START;
+        }
 
         PRINTF("Application update complete\r\n");
       }

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -199,7 +199,14 @@ static uint32_t current_flash_size(void)
     bootloader_settings_t const * boot_setting;
     bootloader_util_settings_get(&boot_setting);
 
+    // bank_0_size counts from DFU_BANK_0_REGION_START (the CRC check and
+    // serial/OTA DFU both define it that way); the dump starts at
+    // USER_FLASH_START, so add the SoftDevice span in between.
     flash_sz = boot_setting->bank_0_size;
+    if ( flash_sz && (flash_sz != 0xFFFFFFFFUL) )
+    {
+      flash_sz += DFU_BANK_0_REGION_START - USER_FLASH_START;
+    }
 
     // Round up to a whole UF2 payload chunk, else the last real chunk of
     // the app would get truncated out of CURRENT.UF2.
@@ -484,6 +491,7 @@ int write_block (uint32_t block_no, uint8_t *data, WriteState *state)
       {
         PRINTF("Write addr = 0x%08lX, block = %ld (%ld of %ld)\r\n", bl->targetAddr, bl->blockNo, state->numWritten, bl->numBlocks);
         flash_nrf5x_write(bl->targetAddr, bl->data, bl->payloadSize, true);
+        if ( bl->targetAddr + bl->payloadSize > state->appEnd ) state->appEnd = bl->targetAddr + bl->payloadSize;
       }else if ( bl->targetAddr < USER_FLASH_START )
       {
         // do nothing if writing to MBR, occurs when SD hex is included

--- a/src/usb/uf2/uf2.h
+++ b/src/usb/uf2/uf2.h
@@ -52,6 +52,7 @@ SOFTWARE.
 typedef struct {
     uint32_t numBlocks;
     uint32_t numWritten;
+    uint32_t appEnd;          // highest end address written in app space (0 if none)
 
     bool aborted;             // aborting update and reset
     bool update_bootloader;   // if updating bootloader (else app)


### PR DESCRIPTION
## Checklist

- [x] PR title specifically describes the change
- [x] `tools/build_all.py` passes
- [x] Tested on real hardware (RAK4631)

-----------

## Description of Change

Follow-up to #20. `bank_0_size` has two meanings depending on who wrote it:

- serial/OTA DFU (`bootloader.c`) and the CRC check: bytes from `DFU_BANK_0_REGION_START`
- `msc_uf2.c`: every UF2 block written from 0x1000 — a `CURRENT.UF2` restore carries the SoftDevice blocks, so that overcounts by the SD span

`ghostfat.c` then uses it as a window from `USER_FLASH_START`. Net effect: after a serial DFU (the Android in-app upgrade path) `CURRENT.UF2` is short by exactly the SoftDevice span — 1.2 MB where 1.5 MB+ is real — and restoring that dump only works while the missing tail is still in flash. Found while hardware-testing #32 (see the thread there; the failed "serial DFU" run was a truncated dump being restored).

Fix: `ghostfat.c` adds the SD span to `bank_0_size`; `msc_uf2.c` records `appEnd - DFU_BANK_0_REGION_START` (highest app address written) instead of `numWritten * 256`.

Verified on RAK4631, app 2.8.0.abd3348 (729,528 B):
- after serial DFU: dump 1,762,304 B = SD span + app rounded to 256 ✔ (was 1.2 MB-class before)
- restore that dump → app boots, config intact, next dump byte-identical and same size ✔ (no overcount)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application size detection during firmware updates.
  - Corrected flash-size reporting across memory regions.
  - Ensured UF2 application writes track the full written address range.
  - Rounded valid flash sizes to complete UF2 payload chunks for more reliable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->