### PR TITLE
ci: build jobs read-only, one release job holds the write token

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -10,10 +10,11 @@ on:
 
 # The repo's default is write (checked via `gh api .../actions/permissions/workflow`),
 # so every job here would otherwise get a write-capable GITHUB_TOKEN even
-# though only the release-asset upload needs one — and this workflow now
-# runs on every PR, including from forks. contents:write is scoped to the
-# one job that needs it (the release step, gated separately by
-# `if: github.event_name == 'release'`); everything else gets read-only.
+# though only the release-asset upload needs one — and this workflow runs on
+# every PR. Every job that runs PR-controlled code (make, the Python tools)
+# is read-only and does not persist the checkout token; contents:write lives
+# only in the `release` job, which runs on release events and only uploads
+# what the build jobs already produced.
 permissions:
   contents: read
 
@@ -39,11 +40,10 @@ jobs:
           echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
 
   # The factory-erase UF2 is one file for every board, so it is checked in and
-  # attached once (below) rather than by each of the 17 build jobs, which would
-  # race deleting and re-uploading the same asset name. This check runs on
-  # every PR with a read-only token; the upload is a separate release-only job
-  # so PR-modifiable code never runs with contents: write. Not a required
-  # status check on master unless a human adds it to branch protection.
+  # attached once by the `release` job rather than by each of the 17 build
+  # jobs, which would race deleting and re-uploading the same asset name.
+  # Not a required status check on master unless a human adds it to branch
+  # protection.
   factory-erase-uf2:
     runs-on: ubuntu-latest
     permissions:
@@ -59,30 +59,11 @@ jobs:
           python3 tools/make_factory_erase_uf2.py /tmp/meshtastic_factory_erase.uf2
           cmp /tmp/meshtastic_factory_erase.uf2 tools/meshtastic_factory_erase.uf2
 
-  factory-erase-uf2-release:
-    needs: factory-erase-uf2
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' }}
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Upload Release Asset
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          files: tools/meshtastic_factory_erase.uf2
-
   build:
     needs: set-matrix
     runs-on: ubuntu-latest
-    # Only this job's release step needs write access (softprops/action-gh-release
-    # creating/updating release assets); PR runs never reach that step.
     permissions:
-      contents: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -93,6 +74,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
+        persist-credentials: false
 
     - name: Install ARM GCC
       uses: carlosperate/arm-none-eabi-gcc-action@98c40e51546516419841748d3210c290df0d2c6c # v1.13.0
@@ -114,11 +96,30 @@ jobs:
         path: _bin/${{ matrix.board }}
         retention-days: ${{ github.event_name == 'release' && 90 || 1 }}
 
-    - name: Upload Release Asset
-      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-      if: ${{ github.event_name == 'release' }}
-      with:
-        files: |
-          _bin/${{ matrix.board }}/${{ matrix.board }}_bootloader-*.zip
-          _bin/${{ matrix.board }}/${{ matrix.board }}_bootloader-*.hex
-          _bin/${{ matrix.board }}/update-${{ matrix.board }}_bootloader-*.uf2
+  # The only job with write access. It runs no repo code: it re-uploads the
+  # build jobs' artifacts and the checked-in factory-erase file.
+  release:
+    needs: [build, factory-erase-uf2]
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: _bin
+
+      - name: Upload Release Assets
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        with:
+          files: |
+            _bin/*/*_bootloader-*.zip
+            _bin/*/*_bootloader-*.hex
+            _bin/*/update-*_bootloader-*.uf2
+            tools/meshtastic_factory_erase.uf2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,10 +131,13 @@ submodule) — `SD_NAME`/`SD_VERSION` in `Makefile` select which one.
 ### CI (`.github/workflows/githubci.yml`)
 
 A `set-matrix` job lists `src/boards/*/` and fans out a `build` job per
-board (currently 17), on every PR and on `release: created`. Release events
-additionally upload `.zip`/`.hex`/`update-*.uf2` per board as release
-assets; PR runs just validate the compile and get 1-day artifact retention
-(release runs keep 90).
+board (currently 17), on every PR and on `release: created`. On release
+events a single `release` job downloads every board's artifacts and uploads
+`.zip`/`.hex`/`update-*.uf2` per board plus `tools/meshtastic_factory_erase.uf2`
+as release assets; PR runs just validate the compile and get 1-day artifact
+retention (release runs keep 90). Only `release` holds `contents: write` —
+every job that runs repo code (`make`, `tools/`) is read-only with
+`persist-credentials: false`, so a PR cannot borrow a write token.
 
 Branch protection on `master` requires all 18 checks (`set-matrix` + 17
 `build (<board>)` contexts) by literal name. **Adding, removing, or renaming


### PR DESCRIPTION
## Checklist

- [x] PR title specifically describes the change
- [x] `tools/build_all.py` (or CI's board matrix) passes - no code change, the matrix runs on this PR

-----------

## Description of Change

Follow-up to #41 (https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/pull/41#discussion_r3940936549): the 17 `build` jobs ran `make` - and whatever a PR puts in the Makefile and `tools/` - with `contents: write` on every pull request, with the token persisted in `.git/config`. Only the release-asset upload needs write, and only on release events.

- `build` and `factory-erase-uf2`: `contents: read`, `persist-credentials: false`.
- New `release` job, `if: release`, `needs: [build, factory-erase-uf2]`: downloads every board's artifact (`actions/download-artifact` v8, pinned by digest like the other actions) and uploads `.zip`/`.hex`/`update-*.uf2` per board plus `tools/meshtastic_factory_erase.uf2`. Replaces both the per-board upload step and #41's separate erase-file release job.
- `build (<board>)` check names are unchanged, so branch protection on `master` needs no edit. `release` is a new context that only exists on release runs.

Exposure was same-repo branches only (fork PRs get a read-only token regardless), so this is defense in depth, not a hole.

`actionlint` clean apart from the pre-existing shellcheck notes in `set-matrix`. The `release` job cannot be exercised by a PR run; first real exercise is the next release tag - check that all 52 assets (17 boards x 3 files, plus the erase file) land.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Release assets are now assembled and uploaded through a centralized release process.
  - Board-specific archives, firmware files, update packages, bootloader artifacts, and the factory-erase utility are published together.

- **Documentation**
  - Updated CI documentation to reflect the revised release asset workflow and permission model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->