### PR TITLE
docs: OTAFIX 2.4 changelog entry

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
 # Adafruit nRF52 Bootloader Changelog
 
-OTAFIX 2.1–2.3 are Meshtastic's fork; everything from 0.6.2 down predates
+OTAFIX 2.1–2.4 are Meshtastic's fork; everything from 0.6.2 down predates
 it and is upstream Adafruit history, kept for provenance.
 
-## Unreleased
+## OTAFIX 2.4
 
 - Factory erase from the bootloader, no application and no serial terminal needed. Dropping `meshtastic_factory_erase.uf2` (a single UF2 block with family ID `0x4D455348`, board-agnostic, checked in under `tools/` and attached to every release) onto the UF2 drive erases the whole App Data reservation — the application's LittleFS (config, keys, bonds) and, below it, firmware's `WarmNodeStore` node-DB ring at `0xEA000` — and reboots straight back into UF2 mode for the firmware install. The application and bootloader settings are left intact, so a device unplugged at that point boots its app factory-fresh. Replaces the `nrf52_factory_erase` sketch flow, which had to be flashed as the application, waited for a serial terminal to open before erasing, and shipped in two SoftDevice-specific variants. After the erase the bootloader keeps servicing USB for 500 ms so the host's trailing FAT writes are acknowledged and the copy completes cleanly (the RP2040 bootrom does the same), then detaches and resets; ejecting the drive resets it immediately. `INFO_UF2.TXT` gains a `Factory-Erase:` line so flashers can tell whether a bootloader supports it; older bootloaders ignore the file without error. `DFU_MAGIC_*` moved from `main.c` to `src/dfu_magic.h`. Verified on RAK4631 (stock 0.4.3 → this build over UF2): the drive drops 1.3 s after the copy and is back in UF2 mode at 2.9 s; a firmware UF2 copied to it boots with region UNSET, default owner, and an empty node DB.
 


### PR DESCRIPTION
Names the Unreleased section for the `0.9.2-OTAFIX2.4` release: bootloader factory erase (#41) and read-only build jobs with a single release job (#42). Tag after this merges so the release ships a dated changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a board-agnostic factory-erase UF2 file that erases application data and the node database, then reboots into UF2 mode.
  * Added factory-erase status information to `INFO_UF2.TXT`.
  * Improved erase completion by allowing time for final USB storage writes.

* **Documentation**
  * Added OTAFIX 2.4 release notes and updated fork-provenance coverage.
  * Documented the UF2 factory-erase workflow as the replacement for the previous sketch-based process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->