### PR TITLE
chore(renovate): stop proposing lib/nrfx bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,8 +114,10 @@ Renovate will keep proposing. nrfx 4.0 restructured the entire repo layout
 repo's Makefile `IPATH`s and every board's linker script reworked, not just
 a digest bump. v3.14.0 is the last tag on the pre-4.0 layout, so it's the
 practical ceiling for a same-day bump; going past it is a real project, not
-a Renovate merge. If a future Renovate PR targets nrfx ≥4.0, that's this
-gotcha firing — don't merge it without doing that rework.
+a Renovate merge. `renovate.json` disables `lib/nrfx` updates for exactly this
+reason, so no nrfx bump PR should appear at all; if one does, that rule has
+broken and the PR still must not be merged without the rework. Drop the rule
+when the rework lands. `lib/tinyusb` and `lib/uf2` are unaffected.
 
 `lib/tinyusb`'s `nrf5x` USB port (`dcd_nrf5x.c`) calls nrfx's chip-specific
 errata functions (e.g. `nrf52_errata_199()`) — bumping tinyusb alone,

--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,13 @@
   "git-submodules": {
     "enabled": true
   },
+  "packageRules": [
+    {
+      "description": "lib/nrfx is pinned to v3.14.0, the last tag on the pre-4.0 repo layout. nrfx 4.0 moved mdk/ under bsp/, which breaks every Makefile IPATH and board linker script here, so any digest bump past 3.14.0 fails all board builds. Moving to 4.x is a rework, not a digest bump. Remove this rule when that rework lands. See AGENTS.md, Vendored submodules (lib/).",
+      "matchManagers": ["git-submodules"],
+      "matchDepNames": ["lib/nrfx"],
+      "enabled": false
+    }
+  ],
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
## Description of Change

Renovate keeps opening the same unmergeable `lib/nrfx` digest PR. This adds a `packageRule` that disables updates for that one submodule, so it stops.

The current instance is #44, which proposes `1b7bedb` - nrfx 4.5.0, released 2026-07-23. We are pinned at `11f57e5`, nrfx 3.14.0, released 2025-08-21.

nrfx 4.0 restructured the repo. At 3.14.0 the top level of nrfx has `mdk/`. At 4.5.0 it does not, and there is `bsp/` and `lib/` instead. This repo's Makefile `IPATH`s and every board linker script assume the old layout, so nothing compiles:

```
lib/sdk11/components/libraries/bootloader_dfu/dfu_ble_svc.h:39:10: fatal error: nrf.h: No such file or directory
make: *** [Makefile:405: _build/build-promicro_nrf52840/dfu_ble_svc.o] Error 1
```

All 17 `build (<board>)` jobs on #44 fail that way, and have on every run since the PR was first filed in August.

`AGENTS.md` already documents 3.14.0 as a deliberate pin and says a jump to 4.x is a rework of the `IPATH`s and the linker scripts, not a digest bump. The config had no rule to match, so Renovate could not know that.

This is the durable fix. Closing #44 on its own only tells Renovate to skip that one digest - the next upstream commit brings the PR straight back.

The rule is scoped to `lib/nrfx` only. `lib/tinyusb` and `lib/uf2` are untouched and keep getting update PRs. `git-submodules` stays enabled.

Validated with `renovate-config-validator` (renovate 44.61.3, matching the version the bot reports): passes.

Remove the rule when the 4.x rework lands.

#44 is closed in favour of this.
