### PR TITLE
fix(build): make $(BUILD) an order-only prerequisite of the object rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,17 +400,20 @@ linkermap: $(BUILD)/$(OUT_NAME).out
 	@linkermap -v $<.map
 
 # Create objects from C SRC files
-$(BUILD)/%.o: %.c
+# $(BUILD) is order-only: it must exist before any object is written, but its
+# mtime changes as objects land in it, so a normal prerequisite would relink
+# and rebuild spuriously.
+$(BUILD)/%.o: %.c | $(BUILD)
 	@echo CC $(notdir $<)
 	@$(CC) $(CFLAGS) $(INC_PATHS) -c -o $@ $<
 
 # Assemble files
-$(BUILD)/%.o: %.S
+$(BUILD)/%.o: %.S | $(BUILD)
 	@echo AS $(notdir $<)
 	@$(CC) -x assembler-with-cpp $(ASFLAGS) $(INC_PATHS) -c -o $@ $<
 
 # Link
-$(BUILD)/$(OUT_NAME).out: $(BUILD) $(OBJECTS)
+$(BUILD)/$(OUT_NAME).out: $(OBJECTS) | $(BUILD)
 	@echo LD $(notdir $@)
 	@$(CC) -o $@ $(LDFLAGS) $(OBJECTS) -Wl,--start-group $(LIBS) -Wl,--end-group
 	@$(SIZE) $@


### PR DESCRIPTION
Follow-up to #49. That fixed `build_all.py` crashing on macOS; this fixes the board failures it then started reporting.

## The bug

The object rules did not depend on `$(BUILD)` at all. The directory was only a prerequisite of the link rule:

```make
$(BUILD)/$(OUT_NAME).out: $(BUILD) $(OBJECTS)
```

Under `make -j` those two prerequisites are built concurrently, so a compile can start before `mkdir` has run. Serially, make happens to build `$(BUILD)` first, which is why only parallel builds broke.

`-fstack-usage` writes the `.su` *during* compilation and the `.o` at the end, so a `mkdir` landing between the two fails the `.su` while the `.o` succeeds. That is the odd error this produces:

```
fatal error: cannot open _build/build-<board>/<file>.su for writing: No such file or directory
```

`tools/build_all.py` runs a `make -j` per board across a process pool, so it hit this constantly and non-deterministically, on different boards each run. CONTRIBUTING tells contributors to run it before opening a PR. CI never saw it because each board gets its own job.

## Why order-only

`$(BUILD)`'s mtime changes every time an object lands in it, so a normal prerequisite would relink on every build. The link rule is switched to order-only too, which removes that spurious relink as well.

## Measured

macOS, ARM GCC 13.3.Rel1.

| | result |
|---|---|
| before, 19-board tree, clean | 16/19 |
| before, 17-board tree, earlier | 15/17, then 8/17 |
| after | 19/19, three consecutive clean runs |

A second `make BOARD=t1000_e all` after a full build recompiles nothing, confirming the order-only prerequisite did not introduce churn.

The Makefile is CRLF throughout; this keeps it that way, so the diff is 6 lines added and 3 removed rather than a whole-file rewrite.
